### PR TITLE
fix: intercept Twitch page integrity token and auto-detect userId

### DIFF
--- a/src/background/twitch-api/client.ts
+++ b/src/background/twitch-api/client.ts
@@ -4,6 +4,16 @@ import { TwitchSession } from './types';
 
 const DROPS_TAG_ID = 'c2542d6d-cd10-4532-919b-3d19f30a768b';
 
+const CURRENT_USER_QUERY = {
+  operationName: 'CoreActionsCurrentUser',
+  extensions: {
+    persistedQuery: {
+      version: 1,
+      sha256Hash: '6b5b63a013cf66a995d61f71a508ab5c8e4473350c5d4136f846ba65e8101e95',
+    },
+  },
+};
+
 const VIEWER_DROPS_DASHBOARD_QUERY = {
   operationName: 'ViewerDropsDashboard',
   variables: {
@@ -365,6 +375,12 @@ export class TwitchApiClient {
 
   constructor(session: TwitchSession) {
     this.transport = new TwitchGqlTransport(session);
+  }
+
+  async fetchCurrentUserId(): Promise<string | null> {
+    const data = await this.transport.postAuthorized<{ currentUser?: { id?: string } }>(CURRENT_USER_QUERY);
+    const userId = data.currentUser?.id;
+    return typeof userId === 'string' && userId.trim() ? userId.trim() : null;
   }
 
   async fetchDropsSnapshot(): Promise<DropsSnapshot> {

--- a/src/background/twitch-api/gql.ts
+++ b/src/background/twitch-api/gql.ts
@@ -2,6 +2,8 @@ import { DEFAULT_TWITCH_CLIENT_ID, TwitchGraphQLResponse, TwitchSession } from '
 
 const GQL_ENDPOINT = 'https://gql.twitch.tv/gql';
 const INTEGRITY_ENDPOINT = 'https://gql.twitch.tv/integrity';
+const INTEGRITY_CLIENT_ID = 'ue6666qo983tsx6so1t0vnawi233wa';
+const INTEGRITY_CLIENT_VERSION = 'da69d5f2-ac48-4169-9574-48fee4a96513';
 
 function createErrorFromResponse(payload: unknown): Error {
   if (Array.isArray(payload)) {
@@ -116,10 +118,11 @@ export async function fetchTwitchIntegrityToken(session: TwitchSession): Promise
   const response = await fetch(INTEGRITY_ENDPOINT, {
     method: 'POST',
     headers: {
-      'Client-Id': session.clientId || DEFAULT_TWITCH_CLIENT_ID,
+      'Client-Id': INTEGRITY_CLIENT_ID,
       Authorization: `OAuth ${session.oauthToken}`,
       'X-Device-Id': session.deviceId,
       'Client-Session-Id': session.uuid,
+      'Client-Version': INTEGRITY_CLIENT_VERSION,
     },
   });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -102,6 +102,7 @@ export type MessageType =
   | 'UPDATE_GAMES'
   | 'SYNC_DROPS_DATA'
   | 'SYNC_TWITCH_SESSION'
+  | 'SYNC_TWITCH_INTEGRITY'
   | 'PLAY_ALERT'
   | 'OPEN_STREAMER';
 


### PR DESCRIPTION
The integrity token fetched from the Service Worker context gets rejected by Twitch because it's bound to the page's browser context. The working approach (used by other extensions) is to intercept the integrity token that Twitch's own JS generates on the page.

Changes:
- Add fetch interceptor in content script that captures integrity tokens from Twitch's requests to gql.twitch.tv/integrity
- Forward intercepted tokens to background via SYNC_TWITCH_INTEGRITY
- Prefer page-intercepted integrity tokens over API-fetched ones
- Store full integrity object (token + expiration + request_id) with expiration tracking
- Add CoreActionsCurrentUser query to auto-detect userId when missing
- Restore original integrity endpoint constants (matching working extensions that use ue6666qo983tsx6so1t0vnawi233wa for integrity)

https://claude.ai/code/session_01BEWnn3dpnApd3qUoY7EUpF