### PR TITLE
fix: inject integrity interceptor in MAIN world at document_start

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -30,6 +30,12 @@
   "content_scripts": [
     {
       "matches": ["https://*.twitch.tv/*", "https://twitch.tv/*"],
+      "js": ["integrity-interceptor.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
+    {
+      "matches": ["https://*.twitch.tv/*", "https://twitch.tv/*"],
       "js": ["content.js"],
       "run_at": "document_idle"
     }

--- a/src/content/integrity-interceptor.ts
+++ b/src/content/integrity-interceptor.ts
@@ -1,0 +1,45 @@
+// This script runs in the MAIN world at document_start to intercept
+// Twitch's own fetch calls to the integrity endpoint. The captured
+// integrity token is stored in sessionStorage so the content script
+// (running in ISOLATED world) can forward it to the background.
+
+const STORAGE_KEY = '__drophunter_integrity__';
+
+const originalFetch = window.fetch;
+
+window.fetch = function (...args: Parameters<typeof fetch>): ReturnType<typeof fetch> {
+  const url = typeof args[0] === 'string' ? args[0] : args[0] instanceof Request ? args[0].url : '';
+  const promise = originalFetch.apply(this, args);
+
+  if (url.includes('gql.twitch.tv/integrity')) {
+    promise
+      .then((response) => {
+        const clone = response.clone();
+        return clone.json();
+      })
+      .then((data: unknown) => {
+        const payload = data as Record<string, unknown> | null;
+        if (payload && typeof payload.token === 'string' && payload.token.length > 0) {
+          const integrity = {
+            token: payload.token,
+            expiration: typeof payload.expiration === 'number' ? payload.expiration : 0,
+            request_id: typeof payload.request_id === 'string' ? payload.request_id : '',
+            timestamp: Date.now(),
+          };
+          try {
+            window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(integrity));
+          } catch {
+            // sessionStorage might be full or blocked
+          }
+          window.dispatchEvent(
+            new CustomEvent(STORAGE_KEY, { detail: JSON.stringify(integrity) }),
+          );
+        }
+      })
+      .catch(() => {
+        // Silently ignore errors in the interceptor
+      });
+  }
+
+  return promise;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,11 +31,13 @@ export default defineConfig({
         monitor: resolve(__dirname, 'monitor.html'),
         background: resolve(__dirname, 'src/background/service-worker.ts'),
         content: resolve(__dirname, 'src/content/content-script.ts'),
+        'integrity-interceptor': resolve(__dirname, 'src/content/integrity-interceptor.ts'),
       },
       output: {
         entryFileNames: (chunkInfo) => {
           if (chunkInfo.name === 'background') return 'background.js';
           if (chunkInfo.name === 'content') return 'content.js';
+          if (chunkInfo.name === 'integrity-interceptor') return 'integrity-interceptor.js';
           return 'assets/[name]-[hash].js';
         },
         chunkFileNames: 'assets/[name]-[hash].js',


### PR DESCRIPTION
The previous approach injected the fetch interceptor from the content script at document_idle, which was too late - Twitch had already fetched its integrity token by then.

Now uses a dedicated MAIN world content script registered at document_start that patches fetch before Twitch's code runs. The intercepted integrity token is stored in sessionStorage so the content script (ISOLATED world, document_idle) can read it and forward to the background service worker.

- Add integrity-interceptor.ts as a separate build entry
- Register it in manifest as MAIN world, document_start script
- Content script reads from sessionStorage + listens for live events
- Remove old inline script injection approach

https://claude.ai/code/session_01BEWnn3dpnApd3qUoY7EUpF