### PR TITLE
fix: fetch DropCampaignDetails to get timeBasedDrops

### DIFF
--- a/src/background/twitch-api/gql.ts
+++ b/src/background/twitch-api/gql.ts
@@ -108,6 +108,25 @@ export class TwitchGqlTransport {
 
     return typed.data;
   }
+
+  async postAuthorizedBatch<T>(payloads: unknown[]): Promise<Array<TwitchGraphQLResponse<T>>> {
+    const response = await fetch(GQL_ENDPOINT, {
+      method: 'POST',
+      headers: this.buildAuthorizedHeaders(),
+      body: JSON.stringify(payloads),
+    });
+
+    const json = await response.json().catch(() => null);
+    if (!response.ok) {
+      throw new Error(`Twitch GQL HTTP ${response.status}`);
+    }
+
+    if (!Array.isArray(json)) {
+      throw new Error('Expected batched response from Twitch GQL.');
+    }
+
+    return json as Array<TwitchGraphQLResponse<T>>;
+  }
 }
 
 export async function fetchTwitchIntegrityToken(session: TwitchSession): Promise<string | null> {


### PR DESCRIPTION
The ViewerDropsDashboard query returns campaigns WITHOUT timeBasedDrops. Our extension expected them in the response, causing drops count to always be 0.

Now fetches DropCampaignDetails for each connected campaign (in batches of 20) to get the timeBasedDrops data, matching the approach used by TwitchDropsMiner and the working reference extension.

- Add postAuthorizedBatch to GQL transport for batch requests
- Add DropCampaignDetails query (hash 039277bf...)
- Fetch campaign details in parallel batches of 20
- Merge detailed campaign data (with timeBasedDrops) into campaigns

https://claude.ai/code/session_01BEWnn3dpnApd3qUoY7EUpF