### PR TITLE
Reduce expected autoplay skip logging

### DIFF
--- a/src/content/content-script.ts
+++ b/src/content/content-script.ts
@@ -255,9 +255,9 @@ function prepareStreamPlayback() {
     }
     if (video.paused) {
       if (!navigator.userActivation?.hasBeenActive) {
-        console.warn(LOG_PREFIX, 'Playback skipped: user interaction required for autoplay', {
-          hasBeenActive: false,
-        });
+        if (import.meta.env.DEV) {
+          console.debug(LOG_PREFIX, 'Playback skipped: user interaction required for autoplay');
+        }
       } else {
         video.play().catch((err) => {
           console.warn(LOG_PREFIX, 'Playback failed:', err.message, {


### PR DESCRIPTION
### Motivation
- Avoid noisy production warnings and object-attached logs from the content script when autoplay is skipped due to lack of user activation, while keeping the existing API contract that signals `userInteractionRequired` to the background.

### Description
- Replace the production `console.warn` on the autoplay-skip branch with a dev-only `console.debug` and remove the attached object payload so no `[object Object]` appears in extension logs.
- Keep the `console.warn` for genuine playback failures (the `Playback failed:` branch) and preserve the returned `userInteractionRequired` value from `prepareStreamPlayback()`.

### Testing
- Ran TypeScript check with `bun run test:ts`, linting with `bun run lint`, unit tests with `bun run test` (all tests passed), and built artifacts with `bun run build` (build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbb2b31e6483259718b9333ef8327b)