### PR TITLE
Tame stream recovery flow

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -17,6 +17,9 @@
   "host_permissions": [
     "https://*.twitch.tv/*"
   ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self';"
+  },
   "action": {
     "default_popup": "popup.html",
     "default_title": "DropHunter",

--- a/scripts/release-check-ui.mjs
+++ b/scripts/release-check-ui.mjs
@@ -12,6 +12,7 @@ const ANSI = {
   yellow: '\x1b[38;5;226m',
   red: '\x1b[38;5;203m',
 };
+const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, 'g');
 
 function now() {
   return performance.now();
@@ -39,6 +40,106 @@ function outputText(result) {
 
 function hasWarningOutput(result) {
   return WARNING_PATTERN.test(outputText(result));
+}
+
+function stripAnsi(value) {
+  return value.replace(ANSI_ESCAPE_PATTERN, '');
+}
+
+function pushUnique(lines, line) {
+  const normalized = line.trim();
+
+  if (normalized && !lines.includes(normalized)) {
+    lines.push(normalized);
+  }
+}
+
+function shortenPath(path) {
+  return path.replace(/^.*?((?:src|tests|scripts|public)\/)/, '$1');
+}
+
+function extractLocation(line) {
+  const location = line.match(/((?:[./\w-]+\/)?[\w.-]+\.(?:ts|tsx|js|jsx|mjs)):(\d+):(\d+)/);
+
+  if (!location) {
+    return null;
+  }
+
+  return `${shortenPath(location[1])}:${location[2]}:${location[3]}`;
+}
+
+function extractTypeScriptDiagnostic(line) {
+  const diagnostic = line.match(
+    /^(.+?\.(?:ts|tsx|js|jsx|mjs))(?:(?:\((\d+),(\d+)\))|(?::(\d+):(\d+)))\s*:?\s*(.+)$/u,
+  );
+
+  if (!diagnostic || !/\berror\b|TS\d+/i.test(diagnostic[6])) {
+    return null;
+  }
+
+  const row = diagnostic[2] ?? diagnostic[4];
+  const column = diagnostic[3] ?? diagnostic[5];
+
+  return `${shortenPath(diagnostic[1])}:${row}:${column} ${diagnostic[6]}`;
+}
+
+function summarizeFailureOutput(result) {
+  const text = stripAnsi(outputText(result));
+  const lines = text.split(/\r?\n/);
+  const summary = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const typeScriptDiagnostic = extractTypeScriptDiagnostic(trimmed);
+    const location = extractLocation(trimmed);
+
+    if (typeScriptDiagnostic) {
+      pushUnique(summary, typeScriptDiagnostic);
+      continue;
+    }
+
+    if (trimmed.includes('(fail)')) {
+      pushUnique(summary, trimmed.replace(/\s+\[[\d.]+ms\]$/, ''));
+      continue;
+    }
+
+    if (location) {
+      pushUnique(summary, location);
+      continue;
+    }
+
+    if (/^(error|Error|AssertionError|TypeError|ReferenceError|SyntaxError):/.test(trimmed)) {
+      pushUnique(summary, trimmed);
+      continue;
+    }
+
+    if (/^(Expected|Received):/.test(trimmed)) {
+      pushUnique(summary, trimmed);
+    }
+  }
+
+  if (summary.length === 0) {
+    for (const line of lines) {
+      const trimmed = line.trim();
+
+      if (/\berror\b|\bfailed\b|\bexpected\b|\breceived\b/i.test(trimmed)) {
+        pushUnique(summary, trimmed);
+      }
+    }
+  }
+
+  if (summary.length === 0) {
+    const tail = lines
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .slice(-12);
+
+    for (const line of tail) {
+      pushUnique(summary, line);
+    }
+  }
+
+  return summary.slice(0, 16);
 }
 
 function paint(enabled, color, text) {
@@ -114,6 +215,14 @@ function writeDone(write, line, isInteractive) {
 }
 
 function formatOutputBlock(result) {
+  if (result.status === 'failed') {
+    const summary = summarizeFailureOutput(result);
+
+    if (summary.length > 0) {
+      return `Error summary\n${summary.map((line) => `- ${line}`).join('\n')}`;
+    }
+  }
+
   const sections = [];
 
   if (result.stdout.trim()) {

--- a/src/background/api-operations.ts
+++ b/src/background/api-operations.ts
@@ -68,6 +68,61 @@ export async function fetchDropsSnapshotFromApi(
   }
 }
 
+export async function fetchInventorySnapshotFromApi(
+  state: ServiceWorkerState,
+  session: TwitchSession,
+  baseDrops: DropsSnapshot['drops'],
+): Promise<DropsSnapshot | null> {
+  if (baseDrops.length === 0) {
+    return null;
+  }
+
+  const sessionWithIntegrity =
+    state.integrityFallbackActive && Date.now() < state.integrityFallbackActiveUntil
+      ? { ...session, clientIntegrity: undefined }
+      : await ensureSessionIntegrityExt(state, session);
+
+  let client = new TwitchApiClient(sessionWithIntegrity);
+  try {
+    const snapshot = await client.fetchInventorySnapshot(baseDrops);
+    state.apiConsecutiveFailures = 0;
+    state.apiBackoffUntil = 0;
+    return snapshot.drops.length > 0 ? snapshot : null;
+  } catch (error) {
+    const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+    if (message.includes('integrity')) {
+      const refreshedIntegritySession = await ensureSessionIntegrityExt(state, session, true);
+      if (
+        refreshedIntegritySession.clientIntegrity &&
+        refreshedIntegritySession.clientIntegrity !== sessionWithIntegrity.clientIntegrity
+      ) {
+        try {
+          client = new TwitchApiClient(refreshedIntegritySession);
+          const retriedSnapshot = await client.fetchInventorySnapshot(baseDrops);
+          state.apiConsecutiveFailures = 0;
+          state.apiBackoffUntil = 0;
+          return retriedSnapshot.drops.length > 0 ? retriedSnapshot : null;
+        } catch {}
+      }
+
+      try {
+        const sessionWithoutIntegrity: TwitchSession = { ...session, clientIntegrity: undefined };
+        client = new TwitchApiClient(sessionWithoutIntegrity);
+        const fallbackSnapshot = await client.fetchInventorySnapshot(baseDrops);
+        state.integrityFallbackActive = true;
+        state.integrityFallbackActiveUntil = Date.now() + 30 * 60_000;
+        state.apiConsecutiveFailures = 0;
+        state.apiBackoffUntil = 0;
+        return fallbackSnapshot.drops.length > 0 ? fallbackSnapshot : null;
+      } catch {}
+    }
+    state.apiConsecutiveFailures += 1;
+    state.apiBackoffUntil =
+      Date.now() + Math.min(2 ** state.apiConsecutiveFailures * PROGRESS_POLL_MS, 10 * 60_000);
+    return null;
+  }
+}
+
 export async function fetchDirectoryStreamersFromApi(
   state: ServiceWorkerState,
   game: TwitchGame,
@@ -109,6 +164,41 @@ export interface FetchDropsSnapshotFromApiCallbacks {
   }) => Promise<void>;
   onIsLikelyAuthError: (error: unknown) => boolean;
   onClearTwitchSessionCache: (state: ServiceWorkerState) => void;
+}
+
+export interface FetchInventorySnapshotFromApiCallbacks {
+  onEnsureTwitchSession: (forceRefresh?: boolean) => Promise<TwitchSession | null>;
+  onIsLikelyAuthError: (error: unknown) => boolean;
+  onClearTwitchSessionCache: (state: ServiceWorkerState) => void;
+}
+
+export async function fetchInventorySnapshotFromApiWrapper(
+  state: ServiceWorkerState,
+  baseDrops: DropsSnapshot['drops'],
+  forceSessionRefresh: boolean,
+  callbacks: FetchInventorySnapshotFromApiCallbacks,
+  deps: {
+    logWarn: (msg: string, ctx?: unknown) => void;
+  },
+): Promise<DropsSnapshot | null> {
+  const session = await callbacks.onEnsureTwitchSession(forceSessionRefresh);
+  if (!session) {
+    deps.logWarn('Inventory snapshot API skipped: Twitch session missing');
+    return null;
+  }
+
+  try {
+    return await fetchInventorySnapshotFromApi(state, session, baseDrops);
+  } catch (error) {
+    if (callbacks.onIsLikelyAuthError(error)) {
+      callbacks.onClearTwitchSessionCache(state);
+      if (!forceSessionRefresh) {
+        return fetchInventorySnapshotFromApiWrapper(state, baseDrops, true, callbacks, deps);
+      }
+    }
+    deps.logWarn('Twitch inventory snapshot fetch failed:', String(error));
+    return null;
+  }
 }
 
 export async function fetchDropsSnapshotFromApiWrapper(

--- a/src/background/queue-management.ts
+++ b/src/background/queue-management.ts
@@ -1210,6 +1210,10 @@ export async function openBestStreamerForSelectedGame(
 
 export interface RefreshDropsDataCallbacks {
   onFetchDropsSnapshotFromApi: (force?: boolean) => Promise<DropsSnapshot | null>;
+  onFetchInventorySnapshotFromApi?: (
+    baseDrops: TwitchDrop[],
+    force?: boolean,
+  ) => Promise<DropsSnapshot | null>;
   onEvaluateDropTransitions: (previousCompletedIds: Set<string>) => Promise<void>;
   onSaveState: (state: ServiceWorkerState) => Promise<void>;
 }
@@ -1236,16 +1240,13 @@ export async function refreshDropsData(
   const includeInventoryFetch = options.includeInventoryFetch ?? state.appState.isRunning;
   const previousCompletedIds = new Set(state.appState.completedDrops.map((drop) => drop.id));
   let games = state.appState.availableGames;
-  let drops = includeCampaignFetch
-    ? state.cachedDropsSnapshot.length > 0
-      ? state.cachedDropsSnapshot
-      : state.appState.allDrops
-    : state.appState.allDrops;
+  let drops = state.cachedDropsSnapshot.length > 0 ? state.cachedDropsSnapshot : state.appState.allDrops;
   let apiSnapshotUsed = false;
 
-  if (includeCampaignFetch || includeInventoryFetch) {
+  if (includeCampaignFetch) {
     const apiSnapshot = await callbacks.onFetchDropsSnapshotFromApi();
     if (apiSnapshot) {
+      state.lastFullRefreshAt = Date.now();
       games =
         apiSnapshot.games.length > 0
           ? deps.replaceAvailableGames(apiSnapshot.games)
@@ -1260,6 +1261,19 @@ export async function refreshDropsData(
         state.cachedCampaignChannelsMap = apiSnapshot.campaignChannelsMap;
       }
       apiSnapshotUsed = true;
+    }
+  } else if (includeInventoryFetch && callbacks.onFetchInventorySnapshotFromApi) {
+    const baseDrops = state.cachedDropsSnapshot.length > 0 ? state.cachedDropsSnapshot : drops;
+    if (baseDrops.length > 0) {
+      const inventorySnapshot = await callbacks.onFetchInventorySnapshotFromApi(
+        baseDrops,
+        options.forceInventoryFetch,
+      );
+      if (inventorySnapshot?.drops.length) {
+        drops = inventorySnapshot.drops;
+        state.cachedDropsSnapshot = inventorySnapshot.drops;
+        apiSnapshotUsed = true;
+      }
     }
   }
 

--- a/src/background/queue-management.ts
+++ b/src/background/queue-management.ts
@@ -23,12 +23,14 @@ import {
   classifyStreamHealth,
   computeEffectiveStallThreshold,
   computeRecoveryBackoffMs,
-  MAX_NO_PROGRESS_ROTATION_ATTEMPTS,
+  MAX_NO_STREAMERS_RETRIES,
   MAX_PERSISTENT_RECOVERY_CYCLES,
+  MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS,
+  NO_STREAMERS_RETRY_MS,
   nextNoProgressRotationAttempts,
   PROGRESS_STALL_THRESHOLD_MS,
+  STALLED_PROGRESS_RETRY_MS,
   StreamRotationReason,
-  shouldIncrementNoProgressRotationAttempts,
 } from './stream-rotation';
 import { PickStreamerResult, StreamerSelectionPreferences } from './streamer-selection';
 
@@ -70,11 +72,30 @@ function clearStopState(state: ServiceWorkerState) {
   state.appState = clearTerminalStopStatus(state.appState);
 }
 
-function applyRecoveryState(state: ServiceWorkerState, reason: StreamRotationReason, retryAt: number) {
+function applyRecoveryState(state: ServiceWorkerState, reason: StreamRotationReason, retryAt: number | null) {
   state.appState = applyRecoveryStatus(state.appState, {
     reason,
     retryAt,
     attempts: state.stalledRecoveryAttempts,
+  });
+}
+
+function clearNoStreamersRecoveryState(state: ServiceWorkerState) {
+  if (state.appState.recoveryReason !== 'no-streamers') {
+    return;
+  }
+  state.recoveryBackoffUntil = 0;
+  state.lastRecoveryAttemptAt = 0;
+  state.appState = clearRecoveryStatus(state.appState);
+}
+
+function applyNoStreamersRecoveryState(state: ServiceWorkerState, retryAt: number, attempts: number) {
+  state.recoveryBackoffUntil = retryAt;
+  state.lastRecoveryAttemptAt = Date.now();
+  state.appState = applyRecoveryStatus(state.appState, {
+    reason: 'no-streamers',
+    retryAt,
+    attempts,
   });
 }
 
@@ -215,6 +236,67 @@ export async function enterPersistentRecovery(
   }
 }
 
+export async function acquireStreamerForSelectedGame(
+  state: ServiceWorkerState,
+  opts?: {
+    onOpenStreamer?: () => Promise<boolean>;
+    onSkipCurrentGame?: () => Promise<void>;
+    onSaveState?: () => Promise<void>;
+    onSaveTimingState?: (state: ServiceWorkerState) => Promise<void>;
+  },
+): Promise<boolean> {
+  if (!state.appState.selectedGame) {
+    return false;
+  }
+
+  const now = Date.now();
+  const isNoStreamersRecovery = state.appState.recoveryReason === 'no-streamers';
+  if (isNoStreamersRecovery && state.recoveryBackoffUntil > now) {
+    return false;
+  }
+
+  const opened = opts?.onOpenStreamer ? await opts.onOpenStreamer() : false;
+  if (opened) {
+    clearNoStreamersRecoveryState(state);
+    if (opts?.onSaveState) {
+      await opts.onSaveState();
+    }
+    if (opts?.onSaveTimingState) {
+      await opts.onSaveTimingState(state);
+    }
+    return true;
+  }
+
+  const previousAttempts = isNoStreamersRecovery ? Math.max(0, state.appState.recoveryAttempts ?? 0) : 0;
+  if (previousAttempts >= MAX_NO_STREAMERS_RETRIES) {
+    if (opts?.onSkipCurrentGame) {
+      await opts.onSkipCurrentGame();
+    }
+    if (opts?.onSaveState) {
+      await opts.onSaveState();
+    }
+    if (opts?.onSaveTimingState) {
+      await opts.onSaveTimingState(state);
+    }
+    return false;
+  }
+
+  const retryAt = now + NO_STREAMERS_RETRY_MS;
+  applyNoStreamersRecoveryState(state, retryAt, previousAttempts + 1);
+  logWarn('No live streamers found; scheduling one retry', {
+    game: getGameDisplayLabel(state.appState.selectedGame),
+    retryAt,
+    attempts: previousAttempts + 1,
+  });
+  if (opts?.onSaveState) {
+    await opts.onSaveState();
+  }
+  if (opts?.onSaveTimingState) {
+    await opts.onSaveTimingState(state);
+  }
+  return false;
+}
+
 export async function stopFarmingSession(
   state: ServiceWorkerState,
   opts?: {
@@ -290,6 +372,7 @@ export async function advanceQueueIfCompleted(
     onCloseManagedTabIfSafe?: (tabId: number | null) => Promise<boolean>;
     onClearManagedTabOwnership?: () => void;
     onApplyStopState?: (state: ServiceWorkerState, reason: string, message: string | null) => void;
+    onNotify?: (title: string, message: string) => Promise<void>;
     onRefreshDropsData?: (options: {
       includeCampaignFetch: boolean;
       includeInventoryFetch: boolean;
@@ -326,6 +409,11 @@ export async function advanceQueueIfCompleted(
       queueLength: state.appState.queue.length,
     });
   }
+
+  const completedWhileNoStreamers = state.appState.recoveryReason === 'no-streamers';
+  const completedGameName = state.appState.selectedGame
+    ? getGameDisplayLabel(state.appState.selectedGame)
+    : 'current game';
 
   if (state.appState.selectedGame) {
     removeGameFromQueue(state, state.appState.selectedGame);
@@ -394,14 +482,22 @@ export async function advanceQueueIfCompleted(
   state.appState.completionNotified = false;
   state.appState.lastRotationReason = null;
   state.appState.lastRotationAt = null;
+  const queueCompleteMessage = completedWhileNoStreamers
+    ? `Queue completed. No live streamers found for ${completedGameName}.`
+    : 'Queue completed. No pending rewards left.';
+  const queueCompleteNotificationMessage = completedWhileNoStreamers
+    ? `No live streamers found for ${completedGameName}. DropHunter has stopped.`
+    : queueCompleteMessage;
   if (opts?.onApplyStopState) {
-    opts.onApplyStopState(state, 'queue-complete', 'Queue completed. No pending rewards left.');
+    opts.onApplyStopState(state, 'queue-complete', queueCompleteMessage);
   }
   if (opts?.onStopMonitoring) {
     opts.onStopMonitoring();
   }
-  if (opts?.onSendAlert) {
-    await opts.onSendAlert('all-complete', 'Queue completed. No pending rewards left.');
+  if (completedWhileNoStreamers && opts?.onNotify) {
+    await opts.onNotify('Queue completed', queueCompleteNotificationMessage);
+  } else if (opts?.onSendAlert) {
+    await opts.onSendAlert('all-complete', queueCompleteMessage);
   }
   if (opts?.onSaveState) {
     await opts.onSaveState();
@@ -409,8 +505,35 @@ export async function advanceQueueIfCompleted(
   return false;
 }
 
-export async function skipCurrentGameDueToStall(
+export type QueueSkipReason = 'stalled-progress' | 'no-streamers';
+
+function queueSkipCopy(reason: QueueSkipReason, gameName: string) {
+  if (reason === 'no-streamers') {
+    return {
+      logMessage: 'Skipping game because no live streamers were found',
+      skipNotificationTitle: 'Game skipped: no live streamers',
+      skipMessage: `Skipped ${gameName} — no live streamers were found.`,
+      terminalNotificationTitle: 'Queue completed',
+      terminalMessage: `Queue completed. No live streamers found for ${gameName}.`,
+      terminalNotificationMessage: `No live streamers found for ${gameName}. DropHunter has stopped.`,
+      stopReason: 'queue-complete',
+    } as const;
+  }
+
+  return {
+    logMessage: 'Giving up on game after stalled drop progress',
+    skipNotificationTitle: 'Game skipped: no drop progress',
+    skipMessage: `Skipped ${gameName} — stream opened but drop progress did not resume.`,
+    terminalNotificationTitle: 'Farming stopped: no drop progress',
+    terminalMessage: `Farming stopped — ${gameName} opened a stream but drop progress did not resume and no other games are queued.`,
+    terminalNotificationMessage: `${gameName} opened a stream but drop progress did not resume. DropHunter has stopped.`,
+    stopReason: 'stall-skipped',
+  } as const;
+}
+
+export async function skipCurrentGameAndAdvanceQueue(
   state: ServiceWorkerState,
+  reason: QueueSkipReason = 'stalled-progress',
   opts?: {
     onEnsureWorkspace?: () => Promise<void>;
     onRefreshDropsData?: (options: {
@@ -430,9 +553,11 @@ export async function skipCurrentGameDueToStall(
 ) {
   const skippedGame = state.appState.selectedGame;
   const gameName = skippedGame ? getGameDisplayLabel(skippedGame) : 'current game';
+  const copy = queueSkipCopy(reason, gameName);
 
-  logWarn('Giving up on game after persistent recovery exhaustion', {
+  logWarn(copy.logMessage, {
     game: gameName,
+    reason,
     stalledRecoveryAttempts: state.stalledRecoveryAttempts,
   });
 
@@ -482,8 +607,8 @@ export async function skipCurrentGameDueToStall(
       await opts.onOpenStreamer();
     }
     await notify(
-      'Game skipped',
-      `Skipped ${gameName} — no progress after repeated attempts. Now farming ${getGameDisplayLabel(nextGame)}.`,
+      copy.skipNotificationTitle,
+      `${copy.skipMessage} Now farming ${getGameDisplayLabel(nextGame)}.`,
     );
     if (opts?.onSaveState) {
       await opts.onSaveState();
@@ -491,16 +616,24 @@ export async function skipCurrentGameDueToStall(
     return;
   }
 
+  state.appState.selectedGame = null;
   if (opts?.onStopFarmingSession) {
     await opts.onStopFarmingSession({
-      stopReason: 'stall-skipped',
-      stopMessage: `Farming stopped — ${gameName} made no progress and no other games are queued.`,
+      stopReason: copy.stopReason,
+      stopMessage: copy.terminalMessage,
       notification: {
-        title: 'Farming stopped',
-        message: `${gameName} made no progress after repeated recovery attempts.`,
+        title: copy.terminalNotificationTitle,
+        message: copy.terminalNotificationMessage,
       },
     });
   }
+}
+
+export async function skipCurrentGameDueToStall(
+  state: ServiceWorkerState,
+  opts?: Parameters<typeof skipCurrentGameAndAdvanceQueue>[2],
+) {
+  return skipCurrentGameAndAdvanceQueue(state, 'stalled-progress', opts);
 }
 
 export async function handleStartFarming(
@@ -601,23 +734,6 @@ export async function rotateStreamer(
   },
 ): Promise<boolean> {
   state.noProgressRotationAttempts = nextNoProgressRotationAttempts(state.noProgressRotationAttempts, reason);
-  if (state.noProgressRotationAttempts >= MAX_NO_PROGRESS_ROTATION_ATTEMPTS) {
-    if (opts?.onEnterPersistentRecovery) {
-      await opts.onEnterPersistentRecovery(
-        state,
-        reason,
-        "DropHunter hasn't resumed progress yet, but it will keep retrying automatically.",
-        { onSkipCurrentGame: opts.onSkipCurrentGame },
-      );
-    }
-    if (opts?.onSaveState) {
-      await opts.onSaveState();
-    }
-    if (opts?.onSaveTimingState) {
-      await opts.onSaveTimingState(state);
-    }
-    return false;
-  }
 
   state.appState.lastRotationReason = reason;
   state.appState.lastRotationAt = Date.now();
@@ -629,28 +745,8 @@ export async function rotateStreamer(
   if (opts?.onOpenStreamer) {
     opened = await opts.onOpenStreamer();
   }
-  if (!opened && !shouldIncrementNoProgressRotationAttempts(reason)) {
-    state.noProgressRotationAttempts = nextNoProgressRotationAttempts(
-      state.noProgressRotationAttempts,
-      'open-failed',
-    );
-    if (state.noProgressRotationAttempts >= MAX_NO_PROGRESS_ROTATION_ATTEMPTS) {
-      if (opts?.onEnterPersistentRecovery) {
-        await opts.onEnterPersistentRecovery(
-          state,
-          'open-failed',
-          'DropHunter could not reopen a working stream yet, but it will keep retrying automatically.',
-          { onSkipCurrentGame: opts.onSkipCurrentGame },
-        );
-      }
-      if (opts?.onSaveState) {
-        await opts.onSaveState();
-      }
-      if (opts?.onSaveTimingState) {
-        await opts.onSaveTimingState(state);
-      }
-      return false;
-    }
+  if (!opened && reason === 'stalled-progress' && opts?.onSkipCurrentGame) {
+    await opts.onSkipCurrentGame();
   }
 
   if (opts?.onSaveState) {
@@ -713,7 +809,7 @@ export async function rotateStreamerIfInvalid(
     if (
       state.recoveryBackoffUntil > 0 &&
       Date.now() < state.recoveryBackoffUntil &&
-      state.appState.recoveryReason === 'open-failed'
+      (state.appState.recoveryReason === 'open-failed' || state.appState.recoveryReason === 'no-streamers')
     ) {
       return;
     }
@@ -736,7 +832,7 @@ export async function rotateStreamerIfInvalid(
     if (
       state.recoveryBackoffUntil > 0 &&
       Date.now() < state.recoveryBackoffUntil &&
-      state.appState.recoveryReason === 'open-failed'
+      (state.appState.recoveryReason === 'open-failed' || state.appState.recoveryReason === 'no-streamers')
     ) {
       return;
     }
@@ -850,7 +946,9 @@ export async function rotateStreamerIfInvalid(
     if (
       state.recoveryBackoffUntil > 0 &&
       now < state.recoveryBackoffUntil &&
-      (state.appState.recoveryReason === 'offline' || state.appState.recoveryReason === 'open-failed')
+      (state.appState.recoveryReason === 'offline' ||
+        state.appState.recoveryReason === 'open-failed' ||
+        state.appState.recoveryReason === 'no-streamers')
     ) {
       logDebug('Offline detected but in recovery backoff, skipping rotation', {
         recoveryReason: state.appState.recoveryReason,
@@ -888,9 +986,10 @@ export async function rotateStreamerIfInvalid(
   }
 
   if (health.reason === 'stalled-progress') {
-    if (state.stalledRecoveryAttempts > MAX_PERSISTENT_RECOVERY_CYCLES) {
+    if (state.stalledRecoveryAttempts >= MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS) {
       logWarn('Stalled progress recovery exhausted — skipping game', {
         stalledRecoveryAttempts: state.stalledRecoveryAttempts,
+        maxAttempts: MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS,
         progress: state.appState.currentDrop?.progress ?? null,
         currentMinutes: state.appState.currentDrop?.currentMinutes ?? null,
       });
@@ -907,12 +1006,16 @@ export async function rotateStreamerIfInvalid(
       return;
     }
     if (state.lastRecoveryAttemptAt < state.lastProgressAdvanceAt || state.stalledRecoveryAttempts === 0) {
-      state.stalledRecoveryAttempts = Math.max(1, state.stalledRecoveryAttempts + 1);
+      state.stalledRecoveryAttempts = Math.min(
+        MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS,
+        Math.max(1, state.stalledRecoveryAttempts + 1),
+      );
       state.lastRecoveryAttemptAt = now;
-      state.recoveryBackoffUntil = now + computeRecoveryBackoffMs(state.stalledRecoveryAttempts);
+      state.recoveryBackoffUntil = now + STALLED_PROGRESS_RETRY_MS;
       applyRecoveryState(state, 'stalled-progress', state.recoveryBackoffUntil);
       logInfo('Attempting in-place playback self-heal before rotating', {
         stalledRecoveryAttempts: state.stalledRecoveryAttempts,
+        maxAttempts: MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS,
         recoveryBackoffUntil: state.recoveryBackoffUntil,
       });
       if (opts?.onAttemptPlaybackSelfHeal && tab.id) {
@@ -926,7 +1029,14 @@ export async function rotateStreamerIfInvalid(
       }
       return;
     }
+    state.stalledRecoveryAttempts = Math.min(
+      MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS,
+      state.stalledRecoveryAttempts + 1,
+    );
+    applyRecoveryState(state, 'stalled-progress', null);
     logInfo('Drop progress stalled, triggering stream rotation', {
+      stalledRecoveryAttempts: state.stalledRecoveryAttempts,
+      maxAttempts: MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS,
       progress: state.appState.currentDrop?.progress ?? null,
       currentMinutes: state.appState.currentDrop?.currentMinutes ?? null,
       requiredMinutes: state.appState.currentDrop?.requiredMinutes ?? null,
@@ -967,6 +1077,7 @@ export async function rotateStreamerIfInvalid(
 export interface CheckDropProgressCallbacks {
   onEnforcePlaybackPolicy: () => Promise<void>;
   onRotateStreamerIfInvalid: () => Promise<void>;
+  onAcquireStreamerForSelectedGame: () => Promise<boolean>;
   onAttemptAutoClaimChannelPointsBonus: () => Promise<boolean>;
   onRefreshDropsData: (opts?: {
     includeCampaignFetch?: boolean;
@@ -1019,6 +1130,15 @@ export async function checkDropProgress(
   }, TICK_WATCHDOG_TIMEOUT_MS);
 
   try {
+    const noStreamersRecoveryActive =
+      state.appState.recoveryReason === 'no-streamers' && state.recoveryBackoffUntil > 0;
+    if (noStreamersRecoveryActive) {
+      if (Date.now() >= state.recoveryBackoffUntil) {
+        await callbacks.onAcquireStreamerForSelectedGame();
+      }
+      return;
+    }
+
     if (state.appState.tabId) {
       const streamTab = await chrome.tabs.get(state.appState.tabId).catch(() => null);
       if (!streamTab) {
@@ -1043,6 +1163,9 @@ export async function checkDropProgress(
       state.streamValidationGraceUntil = Date.now() + STREAM_VALIDATION_GRACE_MS;
     } else {
       await callbacks.onRotateStreamerIfInvalid();
+      if (!state.appState.isRunning || state.appState.isPaused) {
+        return;
+      }
     }
     await callbacks.onAttemptAutoClaimChannelPointsBonus();
 
@@ -1203,7 +1326,6 @@ export async function openBestStreamerForSelectedGame(
     game: deps.getGameDisplayLabel(state.appState.selectedGame),
     categorySlug: state.appState.selectedGame.categorySlug ?? null,
   });
-  state.appState.tabId = null;
   state.appState.activeStreamer = null;
   return false;
 }

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -54,6 +54,7 @@ import {
 import { createDropsPageRefresher } from './drops-page-refresh.ts';
 import { registerExtensionLifecycleListeners } from './extension-lifecycle.ts';
 import {
+  acquireStreamerForSelectedGame as acquireStreamerForSelectedGameExt,
   advanceQueueIfCompleted as advanceQueueIfCompletedExt,
   applyStopState as applyStopStateExt,
   checkDropProgress as checkDropProgressExt,
@@ -70,6 +71,7 @@ import {
   resolveGameFromState as resolveGameFromStateExt,
   rotateStreamer as rotateStreamerExt,
   rotateStreamerIfInvalid as rotateStreamerIfInvalidExt,
+  skipCurrentGameAndAdvanceQueue as skipCurrentGameAndAdvanceQueueExt,
   skipCurrentGameDueToStall as skipCurrentGameDueToStallExt,
   stopFarmingSession as stopFarmingSessionExt,
 } from './queue-management.ts';
@@ -629,7 +631,7 @@ async function handleStartupResumePolicy() {
     await saveStateExt(state);
     await saveTimingStateExt(state);
     if (!keptExistingTab && state.appState.selectedGame) {
-      await openBestStreamerForSelectedGame();
+      await acquireStreamerForSelectedGame();
     }
     setTimeout(() => {
       if (state.appState.resumedFromCrash != null) {
@@ -949,6 +951,7 @@ async function checkDropProgress() {
   await checkDropProgressExt(state, {
     onEnforcePlaybackPolicy: enforcePlaybackPolicyOnStreamTab,
     onRotateStreamerIfInvalid: rotateStreamerIfInvalid,
+    onAcquireStreamerForSelectedGame: acquireStreamerForSelectedGame,
     onAttemptAutoClaimChannelPointsBonus: attemptAutoClaimChannelPointsBonus,
     onRefreshDropsData: refreshDropsData,
     onAutoClaimClaimableDrops: autoClaimClaimableDrops,
@@ -984,6 +987,26 @@ async function openBestStreamerForSelectedGame(): Promise<boolean> {
   );
 }
 
+async function skipCurrentGameDueToNoStreamers() {
+  await skipCurrentGameAndAdvanceQueueExt(state, 'no-streamers', {
+    onEnsureWorkspace: ensureWorkspaceForSelectedGame,
+    onRefreshDropsData: refreshDropsData,
+    onOpenStreamer: acquireStreamerForSelectedGame,
+    onSaveState: () => saveStateExt(state),
+    onSaveTimingState: saveTimingStateExt,
+    onStopFarmingSession: stopFarmingSession,
+  });
+}
+
+async function acquireStreamerForSelectedGame(): Promise<boolean> {
+  return acquireStreamerForSelectedGameExt(state, {
+    onOpenStreamer: openBestStreamerForSelectedGame,
+    onSkipCurrentGame: skipCurrentGameDueToNoStreamers,
+    onSaveState: () => saveStateExt(state),
+    onSaveTimingState: saveTimingStateExt,
+  });
+}
+
 async function ensureWorkspaceForSelectedGame() {
   if (!appState.selectedGame) {
     return;
@@ -997,13 +1020,16 @@ async function ensureWorkspaceForSelectedGame() {
 
 async function advanceQueueIfCompleted(): Promise<boolean> {
   return advanceQueueIfCompletedExt(state, {
-    onOpenStreamer: openBestStreamerForSelectedGame,
+    onOpenStreamer: acquireStreamerForSelectedGame,
     onEnsureWorkspace: ensureWorkspaceForSelectedGame,
     onSendAlert: sendAlert,
     onStopMonitoring: stopMonitoring,
     onCloseManagedTabIfSafe: closeManagedTabIfSafeExt,
     onClearManagedTabOwnership: () => clearManagedTabOwnershipExt(state),
     onApplyStopState: applyStopStateExt,
+    onNotify: async (title: string, message: string) => {
+      await notify(title, message);
+    },
     onRefreshDropsData: refreshDropsData,
     onSaveState: () => saveStateExt(state),
     onSaveTimingState: saveTimingStateExt,
@@ -1031,7 +1057,7 @@ async function handleStartFarming(payload: { game?: TwitchGame }) {
     return { success: false, error: 'Queue completed. No pending rewards left.' };
   }
   if (!appState.tabId && appState.selectedGame) {
-    await openBestStreamerForSelectedGame();
+    await acquireStreamerForSelectedGame();
   }
   if (appState.monitorAutoOpen) {
     await new Promise((resolve) => setTimeout(resolve, MONITOR_AUTO_OPEN_DELAY_MS));
@@ -1048,7 +1074,7 @@ async function skipCurrentGameDueToOfflineRecovery() {
   await skipCurrentGameDueToStallExt(state, {
     onEnsureWorkspace: ensureWorkspaceForSelectedGame,
     onRefreshDropsData: refreshDropsData,
-    onOpenStreamer: openBestStreamerForSelectedGame,
+    onOpenStreamer: acquireStreamerForSelectedGame,
     onSaveState: () => saveStateExt(state),
     onSaveTimingState: saveTimingStateExt,
     onStopFarmingSession: stopFarmingSession,
@@ -1063,7 +1089,7 @@ async function rotateStreamerIfInvalid() {
     onSaveState: () => saveStateExt(state),
     onSaveTimingState: saveTimingStateExt,
     onRotateStreamer: rotateStreamerExt,
-    onOpenStreamer: openBestStreamerForSelectedGame,
+    onOpenStreamer: acquireStreamerForSelectedGame,
     onEnterPersistentRecovery: enterPersistentRecoveryExt,
     onSkipCurrentGame: skipCurrentGameDueToOfflineRecovery,
   });
@@ -1086,7 +1112,7 @@ async function handleSetSelectedGame(payload: { game: TwitchGame }) {
       onTrackActivity: trackActivity,
       onEnsureWorkspace: ensureWorkspaceForSelectedGame,
       onRefreshDropsData: refreshDropsData,
-      onOpenBestStreamer: openBestStreamerForSelectedGame,
+      onOpenBestStreamer: acquireStreamerForSelectedGame,
       onSaveState: saveStateExt,
       onSaveTimingState: saveTimingStateExt,
     },

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -33,7 +33,11 @@ import {
   waitForTabComplete as waitForTabCompleteExt,
 } from './tab-management.ts';
 import './stream-rotation';
-import { fetchDirectoryStreamersFromApiWrapper, fetchDropsSnapshotFromApiWrapper } from './api-operations.ts';
+import {
+  fetchDirectoryStreamersFromApiWrapper,
+  fetchDropsSnapshotFromApiWrapper,
+  fetchInventorySnapshotFromApiWrapper,
+} from './api-operations.ts';
 import {
   CRASH_DETECTION_THRESHOLD_MS,
   CRASH_RECOVERY_GRACE_MS,
@@ -718,6 +722,23 @@ async function fetchDropsSnapshotFromApi(forceSessionRefresh = false): Promise<D
   );
 }
 
+async function fetchInventorySnapshotFromApi(
+  baseDrops: TwitchDrop[],
+  forceSessionRefresh = false,
+): Promise<DropsSnapshot | null> {
+  return fetchInventorySnapshotFromApiWrapper(
+    state,
+    baseDrops,
+    forceSessionRefresh,
+    {
+      onEnsureTwitchSession: ensureTwitchSession,
+      onIsLikelyAuthError: isLikelyAuthError,
+      onClearTwitchSessionCache: clearTwitchSessionCacheExt,
+    },
+    { logWarn },
+  );
+}
+
 async function fetchDirectoryStreamersFromApi(
   game: TwitchGame,
   forceSessionRefresh = false,
@@ -906,6 +927,7 @@ async function refreshDropsData(options: RefreshDropsOptions = {}) {
     options,
     {
       onFetchDropsSnapshotFromApi: fetchDropsSnapshotFromApi,
+      onFetchInventorySnapshotFromApi: fetchInventorySnapshotFromApi,
       onEvaluateDropTransitions: evaluateDropTransitions,
       onSaveState: saveStateExt,
     },

--- a/src/background/stream-rotation.ts
+++ b/src/background/stream-rotation.ts
@@ -1,7 +1,11 @@
 export const MAX_NO_PROGRESS_ROTATION_ATTEMPTS = 3;
+export const MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS = 3;
+export const STALLED_PROGRESS_RETRY_MS = 60_000;
 export const MAX_PERSISTENT_RECOVERY_CYCLES = 5;
 export const RECOVERY_BACKOFF_BASE_MS = 60_000;
 export const MAX_RECOVERY_BACKOFF_MS = 15 * 60_000;
+export const NO_STREAMERS_RETRY_MS = 60_000;
+export const MAX_NO_STREAMERS_RETRIES = 1;
 
 export const PROGRESS_STALL_THRESHOLD_MS = 5 * 60_000;
 
@@ -13,10 +17,11 @@ export type StreamRotationReason =
   | 'wrong-game'
   | 'drops-inactive'
   | 'stalled-progress'
-  | 'open-failed';
+  | 'open-failed'
+  | 'no-streamers';
 
 export function shouldIncrementNoProgressRotationAttempts(reason: StreamRotationReason): boolean {
-  return reason === 'stalled-progress' || reason === 'open-failed';
+  return reason === 'stalled-progress';
 }
 
 export function nextNoProgressRotationAttempts(

--- a/src/background/twitch-api/claimed-rewards.ts
+++ b/src/background/twitch-api/claimed-rewards.ts
@@ -1,4 +1,3 @@
-import { logVerboseInfo } from '../logging.ts';
 import { normalizeText } from './parsing.ts';
 
 export interface ClaimedRewardEntry {
@@ -39,21 +38,6 @@ export function buildClaimedRewardLookup(inventoryRaw: unknown): ClaimedRewardLo
     const entry = lookup.get(gameName)!;
     if (rewardName) entry.nameCounts.set(rewardName, (entry.nameCounts.get(rewardName) ?? 0) + 1);
     if (benefitId) entry.idCounts.set(benefitId, (entry.idCounts.get(benefitId) ?? 0) + 1);
-    logVerboseInfo(
-      `[buildClaimedRewardLookup] game="${gameName}" claimedName="${rewardName}" benefitId="${benefitId}"`,
-    );
-  });
-
-  lookup.forEach((entry, gameName) => {
-    const nameEntries = Array.from(entry.nameCounts.entries())
-      .map(([name, count]) => `${name}(x${count})`)
-      .join(', ');
-    const idEntries = Array.from(entry.idCounts.entries())
-      .map(([id, count]) => `${id}(x${count})`)
-      .join(', ');
-    logVerboseInfo(
-      `[buildClaimedRewardLookup] SUMMARY game="${gameName}" claimedNames=[${nameEntries}] claimedIdCounts=[${idEntries}]`,
-    );
   });
 
   return lookup;

--- a/src/background/twitch-api/client.ts
+++ b/src/background/twitch-api/client.ts
@@ -1,6 +1,6 @@
 import { toSlug } from '../../shared/utils';
 import { DropStatus, DropsSnapshot, TwitchDrop, TwitchGame, TwitchStreamer } from '../../types';
-import { logDebug, logVerboseInfo, logVerboseWarn, logWarn } from '../logging';
+import { logDebug, logVerboseWarn, logWarn } from '../logging';
 import {
   buildClaimedRewardLookup,
   buildGlobalClaimedIdCounts,
@@ -184,6 +184,75 @@ function buildInventoryDropMaps(inventoryRaw: unknown): InventoryDropMaps {
   return { byCampaignDrop, byDropId };
 }
 
+function findInventoryStateForDrop(
+  drop: TwitchDrop,
+  inventoryMaps: InventoryDropMaps,
+): InventoryDropState | undefined {
+  const dropId = normalizeText(drop.id);
+  if (!dropId) {
+    return undefined;
+  }
+
+  const campaignId = normalizeText(drop.campaignId);
+  return (
+    (campaignId ? inventoryMaps.byCampaignDrop.get(`${campaignId}::${dropId}`) : undefined) ??
+    inventoryMaps.byDropId.get(dropId)
+  );
+}
+
+function applyInventoryStateToDrop(drop: TwitchDrop, inventoryMaps: InventoryDropMaps): TwitchDrop {
+  const inventoryState = findInventoryStateForDrop(drop, inventoryMaps);
+  if (!inventoryState) {
+    return drop;
+  }
+
+  const requiredMinutes = inventoryState.requiredMinutes ?? drop.requiredMinutes ?? null;
+  const currentMinutes = inventoryState.currentMinutes;
+  const claimed = drop.claimed || inventoryState.claimed;
+  const claimId = inventoryState.claimId ?? drop.claimId;
+  const claimableFromApi = !claimed && inventoryState.claimable;
+  const claimableFromProgress = Boolean(
+    !claimed && requiredMinutes !== null && requiredMinutes > 0 && currentMinutes >= requiredMinutes,
+  );
+  const hasDropInstance = Boolean(claimId) && !claimed;
+  const claimable = claimableFromApi || claimableFromProgress || hasDropInstance;
+  const progress =
+    claimed || claimable
+      ? 100
+      : requiredMinutes !== null && requiredMinutes > 0
+        ? Math.max(0, Math.min(100, Math.floor((currentMinutes / requiredMinutes) * 100)))
+        : drop.progress;
+  const remainingMinutes =
+    claimed || claimable || requiredMinutes === null
+      ? 0
+      : Math.max(0, Math.round(requiredMinutes - currentMinutes));
+  const endsAt = inventoryState.endsAt ?? drop.endsAt ?? null;
+
+  return {
+    ...drop,
+    claimId,
+    currentMinutes,
+    claimed,
+    claimable,
+    progress,
+    status: normalizeDropStatus(progress, claimed, claimable),
+    requiredMinutes,
+    remainingMinutes,
+    endsAt,
+    expiresInMs: computeExpiry(endsAt).expiresInMs,
+    progressSource: 'inventory',
+  };
+}
+
+function applyInventoryToDrops(drops: TwitchDrop[], inventoryRaw: unknown): TwitchDrop[] {
+  const inventoryMaps = buildInventoryDropMaps(inventoryRaw);
+  if (inventoryMaps.byCampaignDrop.size === 0 && inventoryMaps.byDropId.size === 0) {
+    return drops;
+  }
+
+  return drops.map((drop) => applyInventoryStateToDrop(drop, inventoryMaps));
+}
+
 function isCampaignConnected(campaign: Record<string, unknown>): boolean {
   const self = campaign.self;
   if (!self || typeof self !== 'object') {
@@ -243,10 +312,6 @@ function parseGameFromCampaign(campaign: Record<string, unknown>): TwitchGame | 
       if (allowedChannels.length === 0) allowedChannels = null;
     }
   }
-  logVerboseInfo(
-    `[parseGameFromCampaign] game="${gameName}" campaign="${campaignId}" campaignName="${campaignName ?? ''}" allowedChannels=${allowedChannels ? JSON.stringify(allowedChannels) : 'null (any channel)'}`,
-  );
-
   return {
     id: campaignId ? `campaign-${campaignId}` : `game-${toSlug(gameName)}`,
     name: gameName,
@@ -311,9 +376,6 @@ function parseCampaignDrops(
     const claimedFromGameEvents = idMatch || nameMatch || globalIdMatch;
     const claimedFromInventory = inventoryState?.claimed ?? Boolean(self.isClaimed ?? drop.isClaimed);
     const claimed = claimedFromGameEvents || claimedFromInventory;
-    logVerboseInfo(
-      `[parseCampaignDrops] drop="${normalizeText(drop.name)}" game="${game.name}" benefitIds=[${benefitIds.join(', ')}] benefitNames=[${benefitNames.join(', ')}] idMatch=${idMatch} nameMatch=${nameMatch} globalIdMatch=${globalIdMatch} claimedFromGameEvents=${claimedFromGameEvents} claimedFromInventory=${claimedFromInventory} claimed=${claimed} hasGameClaimedRewards=${gameClaimedRewards != null}`,
-    );
     const claimableFromApi = inventoryState?.claimable ?? Boolean(self.isClaimable ?? self.canClaim);
     const claimableFromProgress = Boolean(
       !claimed && requiredMinutes !== null && requiredMinutes > 0 && currentMinutes >= requiredMinutes,
@@ -392,10 +454,6 @@ function parseEventBasedDrops(
       globalClaimedIdCounts,
     );
     const claimed = idMatch || nameMatch || globalIdMatch;
-    logVerboseInfo(
-      `[parseEventBasedDrops] drop="${normalizeText(drop.name)}" game="${game.name}" benefitIds=[${benefitIds.join(', ')}] benefitNames=[${benefitNames.join(', ')}] idMatch=${idMatch} nameMatch=${nameMatch} globalIdMatch=${globalIdMatch} claimed=${claimed}`,
-    );
-
     const dropId = parsedDropId || `${game.id}-event-drop-${index + 1}`;
     const name = normalizeText(drop.name) || `Event Drop ${index + 1}`;
     const imageUrl = normalizeImageUrl(getFirstImageUrl(drop)) || game.imageUrl;
@@ -558,48 +616,9 @@ export class TwitchApiClient {
 
     const campaigns = dashboardData.currentUser?.dropCampaigns ?? [];
     const inventoryRaw = inventoryData.currentUser?.inventory;
-    // Guard: validate inventory response structure before casting
-    if (inventoryRaw && typeof inventoryRaw === 'object') {
-      const inv = inventoryRaw as Record<string, unknown>;
-      if (!('dropCampaignsInProgress' in inv)) {
-        logVerboseWarn('[DropHunter] Expected dropCampaignsInProgress field in inventory response');
-      } else {
-        const keys = Object.keys(inv);
-        const gameEventDropsRaw = inv.gameEventDrops;
-        const gameEventDropsCount = Array.isArray(gameEventDropsRaw) ? gameEventDropsRaw.length : 'NOT_ARRAY';
-        const campaignsInProgress = Array.isArray(inv.dropCampaignsInProgress)
-          ? (inv.dropCampaignsInProgress as Array<Record<string, unknown>>)
-          : [];
-        logVerboseInfo(`[TwitchApiClient] Raw inventory keys: [${keys.join(', ')}]`);
-        logVerboseInfo(
-          `[TwitchApiClient] gameEventDrops: count=${gameEventDropsCount}, type=${typeof gameEventDropsRaw}, isNull=${gameEventDropsRaw === null}`,
-        );
-        // Log each in-progress campaign with claimed drops
-        campaignsInProgress.forEach((c) => {
-          if (!c || typeof c !== 'object') return;
-          const cId = normalizeText(c.id);
-          const cGame =
-            c.game && typeof c.game === 'object'
-              ? normalizeText((c.game as Record<string, unknown>).displayName) ||
-                normalizeText((c.game as Record<string, unknown>).name)
-              : '?';
-          const timeBasedDrops = Array.isArray(c.timeBasedDrops)
-            ? (c.timeBasedDrops as Array<Record<string, unknown>>)
-            : [];
-          timeBasedDrops.forEach((d) => {
-            if (!d || typeof d !== 'object') return;
-            const dId = normalizeText(d.id);
-            const self = (d.self && typeof d.self === 'object' ? d.self : {}) as Record<string, unknown>;
-            const isClaimed = Boolean(self.isClaimed ?? d.isClaimed);
-            const currentMin = toNumber(self.currentMinutesWatched ?? d.currentMinutesWatched) ?? 0;
-            const reqMin = toNumber(d.requiredMinutesWatched ?? d.requiredMinutes);
-            logVerboseInfo(
-              `[TwitchApiClient] InProgress campaign="${cId}" game="${cGame}" drop="${dId}" claimed=${isClaimed} progress=${currentMin}/${reqMin}`,
-            );
-          });
-        });
-      }
-    } else {
+    if (inventoryRaw && typeof inventoryRaw === 'object' && !('dropCampaignsInProgress' in inventoryRaw)) {
+      logVerboseWarn('[DropHunter] Expected dropCampaignsInProgress field in inventory response');
+    } else if (!inventoryRaw || typeof inventoryRaw !== 'object') {
       logVerboseWarn(
         `[TwitchApiClient] inventoryRaw is ${inventoryRaw === null ? 'null' : typeof inventoryRaw}`,
       );
@@ -607,9 +626,6 @@ export class TwitchApiClient {
     const inventoryMaps = buildInventoryDropMaps(inventoryRaw);
     const claimedRewards = buildClaimedRewardLookup(inventoryRaw);
     const globalClaimedIdCounts = buildGlobalClaimedIdCounts(inventoryRaw);
-    logVerboseInfo(
-      `[TwitchApiClient] Inventory maps: ${inventoryMaps.byCampaignDrop.size} campaign::drop entries, ${inventoryMaps.byDropId.size} drop entries, ${claimedRewards.size} games with claimed rewards, ${globalClaimedIdCounts.size} global claimed IDs`,
-    );
 
     // Filter to usable (non-expired) campaigns — show all, not just connected ones
     const usableCampaigns = campaigns.filter((c) => c && typeof c === 'object' && isCampaignUsable(c));
@@ -652,11 +668,6 @@ export class TwitchApiClient {
       );
 
       // Parse event-based (subscribe to redeem) drops
-      const hasEventDrops = Array.isArray(mergedCampaign.eventBasedDrops);
-      const eventDropCount = hasEventDrops ? (mergedCampaign.eventBasedDrops as Array<unknown>).length : 0;
-      logVerboseInfo(
-        `[TwitchApiClient] Campaign "${game.name}" (${campaignId}) eventBasedDrops: exists=${hasEventDrops}, count=${eventDropCount}`,
-      );
       const eventDrops = parseEventBasedDrops(mergedCampaign, game, claimedRewards, globalClaimedIdCounts);
 
       const allCampaignDrops = [...campaignDrops, ...eventDrops];
@@ -671,10 +682,37 @@ export class TwitchApiClient {
       drops.push(...allCampaignDrops);
     });
 
+    logDebug('Fetched drops snapshot', {
+      campaigns: usableCampaigns.length,
+      inventoryProgressDrops: inventoryMaps.byCampaignDrop.size,
+      games: games.length,
+      drops: drops.length,
+      claimedRewardGames: claimedRewards.size,
+      globalClaimedIds: globalClaimedIdCounts.size,
+    });
+
     return {
       games,
       drops,
       campaignChannelsMap,
+      updatedAt: Date.now(),
+    };
+  }
+
+  async fetchInventorySnapshot(baseDrops: TwitchDrop[]): Promise<DropsSnapshot> {
+    const data = await this.transport.postAuthorized<{
+      currentUser?: { inventory?: Record<string, unknown> };
+    }>(INVENTORY_QUERY);
+    const inventoryRaw = data.currentUser?.inventory;
+
+    if (inventoryRaw && typeof inventoryRaw === 'object' && !('dropCampaignsInProgress' in inventoryRaw)) {
+      logVerboseWarn('[DropHunter] Expected dropCampaignsInProgress field in inventory response');
+    }
+
+    const drops = applyInventoryToDrops(baseDrops, inventoryRaw);
+    return {
+      games: [],
+      drops,
       updatedAt: Date.now(),
     };
   }

--- a/src/monitor/App.tsx
+++ b/src/monitor/App.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import { loadStoredAppState, subscribeToAppState } from '../shared/app-state-sync';
 import { pickNearestDrop } from '../shared/drop-order';
-import { deriveRuntimeMode, formatRecoveryReason, formatRetryLabel } from '../shared/runtime-status';
+import {
+  deriveRuntimeMode,
+  formatRecoveryAttemptLabel,
+  formatRecoveryReason,
+  formatRetryLabel,
+} from '../shared/runtime-status';
 import { createInitialState } from '../shared/utils';
 import { AppState } from '../types';
 
@@ -33,13 +38,21 @@ function recoveryLabel(reason: string | null | undefined): string | null {
   return formatRecoveryReason(reason);
 }
 
-function retryAtLabel(timestamp?: number | null): string | null {
-  return formatRetryLabel(timestamp);
+function retryAtLabel(timestamp: number | null | undefined, now: number): string | null {
+  return formatRetryLabel(timestamp, now);
+}
+
+function recoveryAttemptLabel(
+  reason: string | null | undefined,
+  attempts: number | null | undefined,
+): string | null {
+  return formatRecoveryAttemptLabel(reason, attempts);
 }
 
 function App() {
   const [state, setState] = useState<AppState>(createInitialState());
   const [lastUpdatedAt, setLastUpdatedAt] = useState<number>(Date.now());
+  const [recoveryNow, setRecoveryNow] = useState(Date.now());
 
   useEffect(() => {
     const syncState = async () => {
@@ -58,6 +71,14 @@ function App() {
 
   const nearestDrop = useMemo(() => pickNearestDrop(state.pendingDrops), [state.pendingDrops]);
   const runtimeMode = deriveRuntimeMode(state);
+  useEffect(() => {
+    if (runtimeMode !== 'recovering') {
+      return;
+    }
+    setRecoveryNow(Date.now());
+    const timer = window.setInterval(() => setRecoveryNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, [runtimeMode]);
   const runStateClass =
     runtimeMode === 'recovering'
       ? 'monitor-pill monitor-pill--recovering'
@@ -110,7 +131,12 @@ function App() {
         {runtimeMode === 'recovering' && state.recoveryReason && (
           <div className="monitor-rotation-reason">
             Recovering: {recoveryLabel(state.recoveryReason)}
-            {retryAtLabel(state.recoveryBackoffUntil) ? ` · ${retryAtLabel(state.recoveryBackoffUntil)}` : ''}
+            {recoveryAttemptLabel(state.recoveryReason, state.recoveryAttempts)
+              ? ` · ${recoveryAttemptLabel(state.recoveryReason, state.recoveryAttempts)}`
+              : ''}
+            {retryAtLabel(state.recoveryBackoffUntil, recoveryNow)
+              ? ` · ${retryAtLabel(state.recoveryBackoffUntil, recoveryNow)}`
+              : ''}
           </div>
         )}
 

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -3,7 +3,12 @@ import { loadStoredAppState, subscribeToAppState } from '../shared/app-state-syn
 import { sortPendingDrops } from '../shared/drop-order';
 import { getGameDisplayLabel } from '../shared/game-selection';
 import { sendRuntimeMessage } from '../shared/messages';
-import { deriveRuntimeMode, formatRecoveryReason, formatRetryLabel } from '../shared/runtime-status';
+import {
+  deriveRuntimeMode,
+  formatRecoveryAttemptLabel,
+  formatRecoveryReason,
+  formatRetryLabel,
+} from '../shared/runtime-status';
 import { createInitialState, isExpiredGame } from '../shared/utils';
 import { AppState, ExpiryStatus, StreamerSelectionMode, TwitchDrop, TwitchGame } from '../types';
 import { logPopupError, logPopupWarn } from './logging';
@@ -102,8 +107,15 @@ function statusReasonLabel(reason: string | null | undefined): string | null {
   return formatRecoveryReason(reason);
 }
 
-function retryLabel(timestamp?: number | null): string | null {
-  return formatRetryLabel(timestamp);
+function retryLabel(timestamp: number | null | undefined, now: number): string | null {
+  return formatRetryLabel(timestamp, now);
+}
+
+function recoveryAttemptLabel(
+  reason: string | null | undefined,
+  attempts: number | null | undefined,
+): string | null {
+  return formatRecoveryAttemptLabel(reason, attempts);
 }
 
 /* ── SVG Icons ── */
@@ -381,6 +393,16 @@ function App() {
     return state.queue.map((q) => fallbackById.get(q.id) ?? q);
   }, [state.queue, sortedGames]);
   const runtimeMode = deriveRuntimeMode(state);
+  const [recoveryNow, setRecoveryNow] = useState(Date.now());
+
+  useEffect(() => {
+    if (runtimeMode !== 'recovering') {
+      return;
+    }
+    setRecoveryNow(Date.now());
+    const timer = window.setInterval(() => setRecoveryNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, [runtimeMode]);
 
   const handleGameSelect = async (gameId: string) => {
     const selected = sortedGames.find((g) => g.id === gameId);
@@ -1096,7 +1118,12 @@ function App() {
           <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2">
             <p className="text-[11px] font-semibold text-yellow-300">
               {statusReasonLabel(state.recoveryReason)}
-              {retryLabel(state.recoveryBackoffUntil) ? ` · ${retryLabel(state.recoveryBackoffUntil)}` : ''}
+              {recoveryAttemptLabel(state.recoveryReason, state.recoveryAttempts)
+                ? ` · ${recoveryAttemptLabel(state.recoveryReason, state.recoveryAttempts)}`
+                : ''}
+              {retryLabel(state.recoveryBackoffUntil, recoveryNow)
+                ? ` · ${retryLabel(state.recoveryBackoffUntil, recoveryNow)}`
+                : ''}
             </p>
           </div>
         )}

--- a/src/shared/runtime-status.ts
+++ b/src/shared/runtime-status.ts
@@ -13,6 +13,8 @@ export interface TerminalStopState {
   message: string | null;
 }
 
+export const MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS = 3;
+
 export function deriveRuntimeMode(
   state: Pick<AppState, 'isRunning' | 'isPaused' | 'recoveryReason' | 'lastStopReason'>,
 ) {
@@ -105,7 +107,9 @@ export function formatRotationReason(reason: string | null | undefined): string 
     case 'navigated-away':
       return 'Tab navigated away';
     case 'open-failed':
-      return 'Reopened stream';
+      return 'Could not open stream';
+    case 'no-streamers':
+      return 'No live streamers found';
     default:
       return reason ?? null;
   }
@@ -114,9 +118,11 @@ export function formatRotationReason(reason: string | null | undefined): string 
 export function formatRecoveryReason(reason: string | null | undefined): string | null {
   switch (reason) {
     case 'stalled-progress':
-      return 'Recovering stalled progress';
+      return 'Checking stalled drop progress';
     case 'open-failed':
-      return 'Retrying stream recovery';
+      return 'Could not open stream';
+    case 'no-streamers':
+      return 'No live streamers found';
     case 'drops-inactive':
       return 'Recovering missing drops signal';
     case 'wrong-game':
@@ -128,6 +134,17 @@ export function formatRecoveryReason(reason: string | null | undefined): string 
     default:
       return reason ?? null;
   }
+}
+
+export function formatRecoveryAttemptLabel(
+  reason: string | null | undefined,
+  attempts: number | null | undefined,
+): string | null {
+  if (reason !== 'stalled-progress' || typeof attempts !== 'number' || !Number.isFinite(attempts)) {
+    return null;
+  }
+  const safeAttempts = Math.max(1, Math.min(MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS, Math.floor(attempts)));
+  return `attempt ${safeAttempts}/${MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS}`;
 }
 
 export function formatRetryLabel(timestamp?: number | null, now = Date.now()): string | null {

--- a/tests/api-operations.test.ts
+++ b/tests/api-operations.test.ts
@@ -3,7 +3,7 @@ import { setupChromeMocks, type ChromeMocks } from './mocks/chrome.ts';
 import { createInitialState } from '../src/shared/utils.ts';
 import type { ServiceWorkerState } from '../src/background/service-worker.ts';
 import type { TwitchSession } from '../src/background/twitch-api/types.ts';
-import type { TwitchGame } from '../src/types/index.ts';
+import type { TwitchDrop, TwitchGame } from '../src/types/index.ts';
 
 let chromeMocks: ChromeMocks;
 
@@ -139,12 +139,38 @@ function buildDropsDashboardResponse(games: TwitchGame[]): unknown {
   };
 }
 
-function buildInventoryResponse(): unknown {
+function buildInventoryResponse(
+  campaigns: Array<{
+    campaignId: string;
+    gameName?: string;
+    drops: Array<{
+      dropId: string;
+      currentMinutes: number;
+      requiredMinutes: number;
+      isClaimed?: boolean;
+      isClaimable?: boolean;
+      dropInstanceID?: string;
+    }>;
+  }> = [],
+): unknown {
   return {
     data: {
       currentUser: {
         inventory: {
-          dropCampaignsInProgress: [],
+          dropCampaignsInProgress: campaigns.map((campaign) => ({
+            id: campaign.campaignId,
+            game: campaign.gameName ? { displayName: campaign.gameName } : undefined,
+            timeBasedDrops: campaign.drops.map((drop) => ({
+              id: drop.dropId,
+              requiredMinutesWatched: drop.requiredMinutes,
+              self: {
+                currentMinutesWatched: drop.currentMinutes,
+                isClaimed: drop.isClaimed ?? false,
+                isClaimable: drop.isClaimable ?? false,
+                dropInstanceID: drop.dropInstanceID,
+              },
+            })),
+          })),
           gameEventDrops: [],
         },
       },
@@ -403,6 +429,69 @@ describe('fetchDropsSnapshotFromApi', () => {
 
     expect(result).toBeNull();
     expect(state.apiConsecutiveFailures).toBeGreaterThan(0);
+  });
+});
+
+describe('fetchInventorySnapshotFromApi', () => {
+  let originalFetch: FetchMock | undefined;
+
+  beforeEach(() => {
+    chromeMocks = setupChromeMocks();
+  });
+
+  afterEach(() => {
+    restoreFetch(originalFetch);
+    chromeMocks.teardown();
+  });
+
+  test('updates cached drop progress with inventory only', async () => {
+    const { fetchInventorySnapshotFromApi } = await import('../src/background/api-operations.ts');
+
+    const state = createMinimalState();
+    const session = createSession();
+    const cachedDrops: TwitchDrop[] = [
+      {
+        id: 'drop-1',
+        name: 'For Honor Drop',
+        gameId: 'campaign-for-honor',
+        gameName: 'For Honor',
+        imageUrl: 'https://example.com/drop.png',
+        progress: 50,
+        currentMinutes: 120,
+        claimed: false,
+        campaignId: 'campaign-for-honor',
+        requiredMinutes: 240,
+        remainingMinutes: 120,
+      },
+    ];
+
+    originalFetch = installFetchMock([
+      async () =>
+        buildInventoryResponse([
+          {
+            campaignId: 'campaign-for-honor',
+            gameName: 'For Honor',
+            drops: [
+              {
+                dropId: 'drop-1',
+                currentMinutes: 180,
+                requiredMinutes: 240,
+              },
+            ],
+          },
+        ]),
+    ]);
+
+    const result = await fetchInventorySnapshotFromApi(state, session, cachedDrops);
+
+    expect(result).not.toBeNull();
+    expect(result?.games).toEqual([]);
+    expect(result?.drops).toHaveLength(1);
+    expect(result?.drops[0].currentMinutes).toBe(180);
+    expect(result?.drops[0].progress).toBe(75);
+    expect(result?.drops[0].remainingMinutes).toBe(60);
+    expect(result?.drops[0].progressSource).toBe('inventory');
+    expect(state.apiConsecutiveFailures).toBe(0);
   });
 });
 

--- a/tests/auto-claim-cross-game.test.ts
+++ b/tests/auto-claim-cross-game.test.ts
@@ -307,11 +307,11 @@ function installFetchMock() {
       }
 
       case 'Inventory': {
-        const scenario = activeSnapshotScenario;
+        const scenario = activeSnapshotScenario ?? snapshotQueue.shift();
         if (!scenario) {
           throw new Error('Unexpected inventory fetch in auto-claim-cross-game test');
         }
-        if (scenario.drops.length === 0) {
+        if (activeSnapshotScenario && scenario.drops.length === 0) {
           activeSnapshotScenario = null;
         }
         return jsonResponse({

--- a/tests/logging-hygiene.test.ts
+++ b/tests/logging-hygiene.test.ts
@@ -12,6 +12,8 @@ const sourceFiles = [
   'src/background/notifications.ts',
   'src/background/playback-orchestrator.ts',
   'src/background/session-orchestrator.ts',
+  'src/background/twitch-api/client.ts',
+  'src/background/twitch-api/claimed-rewards.ts',
   'src/content/logging.ts',
   'src/popup/logging.ts',
   'src/shared/ErrorBoundary.tsx',
@@ -56,5 +58,22 @@ describe('logging hygiene', () => {
     expect(viteConfig).toContain('__DROPHUNTER_DEBUG_LOGS__');
     expect(backgroundLogger).toContain('__DROPHUNTER_DEBUG_LOGS__');
     expect(backgroundLogger).not.toContain('import.meta.env.DEV');
+  });
+
+  test('does not keep per-campaign or per-drop Twitch parser logs', () => {
+    const twitchClient = readFileSync(join(repoRoot, 'src/background/twitch-api/client.ts'), 'utf-8');
+    const claimedRewards = readFileSync(
+      join(repoRoot, 'src/background/twitch-api/claimed-rewards.ts'),
+      'utf-8',
+    );
+
+    expect(twitchClient).not.toContain('[parseGameFromCampaign]');
+    expect(twitchClient).not.toContain('[parseCampaignDrops]');
+    expect(twitchClient).not.toContain('[parseEventBasedDrops]');
+    expect(twitchClient).not.toContain('benefitIds=[');
+    expect(twitchClient).not.toContain('idMatch=');
+    expect(twitchClient).not.toContain('Raw inventory keys');
+    expect(twitchClient).not.toContain('InProgress campaign=');
+    expect(claimedRewards).not.toContain('[buildClaimedRewardLookup]');
   });
 });

--- a/tests/manifest-permissions.test.ts
+++ b/tests/manifest-permissions.test.ts
@@ -10,6 +10,9 @@ interface ExtensionManifest {
   permissions?: string[];
   optional_permissions?: string[];
   host_permissions?: string[];
+  content_security_policy?: {
+    extension_pages?: string;
+  };
   content_scripts?: ManifestContentScript[];
   version?: string;
 }
@@ -38,6 +41,12 @@ describe('manifest permissions', () => {
     expect(hosts).not.toContain('*://*/*');
     expect(hosts).not.toContain('https://*/*');
     expect(hosts).not.toContain('http://*/*');
+  });
+
+  test('declares a strict extension-page content security policy', () => {
+    expect(manifest.content_security_policy?.extension_pages).toBe(
+      "script-src 'self'; object-src 'self';",
+    );
   });
 
   test('uses one Twitch-only host pattern everywhere', () => {

--- a/tests/queue-management.test.ts
+++ b/tests/queue-management.test.ts
@@ -8,15 +8,18 @@ import {
   pushGameToQueue,
   resetStreamTrackingState,
   applyStopState,
+  acquireStreamerForSelectedGame,
   enterPersistentRecovery,
   stopFarmingSession,
   advanceQueueIfCompleted,
+  skipCurrentGameAndAdvanceQueue,
   skipCurrentGameDueToStall,
   handleStartFarming,
   refreshDropsData,
   rotateStreamer,
   rotateStreamerIfInvalid,
   checkDropProgress,
+  openBestStreamerForSelectedGame,
 } from '../src/background/queue-management.ts';
 import { splitDropsForSelectedGame, updateStateFromSnapshot } from '../src/background/drop-processing.ts';
 import { replaceAvailableGames } from '../src/shared/game-selection.ts';
@@ -24,6 +27,7 @@ import type { ServiceWorkerState } from '../src/background/service-worker.ts';
 import { createInitialState } from '../src/shared/utils.ts';
 import type { TwitchGame, TwitchDrop } from '../src/types/index.ts';
 import type { StreamRotationReason } from '../src/background/stream-rotation.ts';
+import { MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS } from '../src/background/stream-rotation.ts';
 
 function createMinimalState(overrides: Partial<ServiceWorkerState> = {}): ServiceWorkerState {
   return {
@@ -383,6 +387,227 @@ describe('enterPersistentRecovery', () => {
     expect(state.recoveryNotificationSent).toBe(true);
 
     await enterPersistentRecovery(state, 'stalled-progress', 'Test message');
+  });
+});
+
+describe('acquireStreamerForSelectedGame', () => {
+  test('sets one-minute no-streamers recovery on first failed acquisition', async () => {
+    const state = createMinimalState({ stalledRecoveryAttempts: 2 });
+    state.appState.selectedGame = createGame({ name: 'Rainbow Six Siege' });
+    const before = Date.now();
+
+    let openCalls = 0;
+    await acquireStreamerForSelectedGame(state, {
+      onOpenStreamer: async () => {
+        openCalls += 1;
+        return false;
+      },
+    });
+
+    expect(openCalls).toBe(1);
+    expect(state.appState.recoveryReason).toBe('no-streamers');
+    expect(state.appState.recoveryAttempts).toBe(1);
+    expect(state.recoveryBackoffUntil).toBeGreaterThanOrEqual(before + 60_000);
+    expect(state.recoveryBackoffUntil).toBeLessThanOrEqual(Date.now() + 60_000);
+    expect(state.stalledRecoveryAttempts).toBe(2);
+  });
+
+  test('does not search again while no-streamers retry backoff is active', async () => {
+    const state = createMinimalState();
+    state.appState.selectedGame = createGame();
+    state.appState.recoveryReason = 'no-streamers';
+    state.appState.recoveryAttempts = 1;
+    state.recoveryBackoffUntil = Date.now() + 60_000;
+
+    let openCalls = 0;
+    await acquireStreamerForSelectedGame(state, {
+      onOpenStreamer: async () => {
+        openCalls += 1;
+        return true;
+      },
+    });
+
+    expect(openCalls).toBe(0);
+  });
+
+  test('skips current game after the one no-streamers retry also fails', async () => {
+    const state = createMinimalState();
+    state.appState.selectedGame = createGame();
+    state.appState.recoveryReason = 'no-streamers';
+    state.appState.recoveryAttempts = 1;
+    state.recoveryBackoffUntil = Date.now() - 1;
+
+    let skipCalled = false;
+    await acquireStreamerForSelectedGame(state, {
+      onOpenStreamer: async () => false,
+      onSkipCurrentGame: async () => {
+        skipCalled = true;
+      },
+    });
+
+    expect(skipCalled).toBe(true);
+    expect(state.stalledRecoveryAttempts).toBe(0);
+  });
+
+  test('clears no-streamers recovery when a streamer opens', async () => {
+    const state = createMinimalState();
+    state.appState.selectedGame = createGame();
+    state.appState.recoveryReason = 'no-streamers';
+    state.appState.recoveryAttempts = 1;
+    state.appState.recoveryBackoffUntil = Date.now() - 1;
+    state.recoveryBackoffUntil = state.appState.recoveryBackoffUntil;
+
+    await acquireStreamerForSelectedGame(state, {
+      onOpenStreamer: async () => true,
+    });
+
+    expect(state.appState.recoveryReason).toBeNull();
+    expect(state.appState.recoveryAttempts).toBeNull();
+    expect(state.recoveryBackoffUntil).toBe(0);
+  });
+});
+
+describe('skipCurrentGameAndAdvanceQueue', () => {
+  test('removes no-streamers game and opens the next queued game', async () => {
+    const mocks = setupChromeMocks();
+    const current = createGame({ id: 'game-1', name: 'No Live Game' });
+    const next = createGame({ id: 'game-2', name: 'Live Game' });
+    const state = createMinimalState();
+    state.appState.selectedGame = current;
+    state.appState.queue = [current, next];
+
+    try {
+      let openedGame: string | null = null;
+      await skipCurrentGameAndAdvanceQueue(state, 'no-streamers', {
+        onSaveTimingState: async () => {},
+        onOpenStreamer: async () => {
+          openedGame = state.appState.selectedGame?.id ?? null;
+          return true;
+        },
+      });
+
+      expect(state.appState.queue.some((game) => game.id === current.id)).toBe(false);
+      expect(state.appState.selectedGame?.id).toBe(next.id);
+      expect(openedGame).toBe(next.id);
+    } finally {
+      mocks.teardown();
+    }
+  });
+
+  test('uses no-streamers-specific skip notification when moving to the next game', async () => {
+    const mocks = setupChromeMocks();
+    const current = createGame({ id: 'game-1', name: 'No Live Game' });
+    const next = createGame({ id: 'game-2', name: 'Live Game' });
+    const state = createMinimalState();
+    state.appState.selectedGame = current;
+    state.appState.queue = [current, next];
+
+    try {
+      await skipCurrentGameAndAdvanceQueue(state, 'no-streamers', {
+        onSaveTimingState: async () => {},
+        onOpenStreamer: async () => true,
+      });
+
+      const notification = mocks.notifications._notifications[0] as { title?: string; message?: string } | undefined;
+      expect(notification?.title).toBe('Game skipped: no live streamers');
+      expect(notification?.message).toContain('Skipped No Live Game');
+      expect(notification?.message).toContain('no live streamers were found');
+      expect(notification?.message).not.toContain('drop progress');
+    } finally {
+      mocks.teardown();
+    }
+  });
+
+  test('uses stalled-progress-specific skip notification when moving to the next game', async () => {
+    const mocks = setupChromeMocks();
+    const current = createGame({ id: 'game-1', name: 'Stalled Game' });
+    const next = createGame({ id: 'game-2', name: 'Live Game' });
+    const state = createMinimalState();
+    state.appState.selectedGame = current;
+    state.appState.queue = [current, next];
+
+    try {
+      await skipCurrentGameAndAdvanceQueue(state, 'stalled-progress', {
+        onSaveTimingState: async () => {},
+        onOpenStreamer: async () => true,
+      });
+
+      const notification = mocks.notifications._notifications[0] as { title?: string; message?: string } | undefined;
+      expect(notification?.title).toBe('Game skipped: no drop progress');
+      expect(notification?.message).toContain('Skipped Stalled Game');
+      expect(notification?.message).toContain('stream opened but drop progress did not resume');
+      expect(notification?.message).not.toContain('no live streamers');
+    } finally {
+      mocks.teardown();
+    }
+  });
+
+  test('stops cleanly when no-streamers skip exhausts the queue', async () => {
+    const current = createGame({ id: 'game-1', name: 'No Live Game' });
+    const state = createMinimalState();
+    state.appState.selectedGame = current;
+    state.appState.queue = [current];
+
+    let stopReason: string | null = null;
+    let stopMessage: string | null = null;
+    await skipCurrentGameAndAdvanceQueue(state, 'no-streamers', {
+      onStopFarmingSession: async (opts) => {
+        stopReason = opts.stopReason;
+        stopMessage = opts.stopMessage;
+      },
+    });
+
+    expect(stopReason).toBe('queue-complete');
+    expect(stopMessage).toContain('Queue completed');
+    expect(stopMessage).toContain('No live streamers found');
+  });
+
+  test('clears stale stalled recovery when no-streamers skip exhausts the queue', async () => {
+    const current = createGame({ id: 'game-1', name: 'No Live Game' });
+    const state = createMinimalState({
+      stalledRecoveryAttempts: 3,
+      recoveryBackoffUntil: Date.now() + 60_000,
+    });
+    state.appState.selectedGame = current;
+    state.appState.queue = [current];
+    state.appState.recoveryReason = 'stalled-progress';
+    state.appState.recoveryBackoffUntil = state.recoveryBackoffUntil;
+    state.appState.recoveryAttempts = 3;
+
+    await skipCurrentGameAndAdvanceQueue(state, 'no-streamers', {
+      onStopFarmingSession: async () => {
+        state.appState.isRunning = false;
+        state.appState.isPaused = false;
+        state.appState.selectedGame = null;
+        state.appState.activeStreamer = null;
+        state.appState.tabId = null;
+      },
+    });
+
+    expect(state.appState.recoveryReason).toBeNull();
+    expect(state.appState.recoveryBackoffUntil).toBeNull();
+    expect(state.appState.recoveryAttempts).toBeNull();
+    expect(state.stalledRecoveryAttempts).toBe(0);
+    expect(state.recoveryBackoffUntil).toBe(0);
+  });
+
+  test('uses stalled-progress-specific terminal notification when no games remain', async () => {
+    const current = createGame({ id: 'game-1', name: 'Stalled Game' });
+    const state = createMinimalState();
+    state.appState.selectedGame = current;
+    state.appState.queue = [current];
+
+    let notification: { title: string; message: string } | null = null;
+    await skipCurrentGameAndAdvanceQueue(state, 'stalled-progress', {
+      onStopFarmingSession: async (opts) => {
+        notification = opts.notification;
+      },
+    });
+
+    expect(notification?.title).toBe('Farming stopped: no drop progress');
+    expect(notification?.message).toContain('Stalled Game');
+    expect(notification?.message).toContain('opened a stream but drop progress did not resume');
+    expect(notification?.message).not.toContain('No live streamers found');
   });
 });
 
@@ -823,7 +1048,8 @@ describe('skipCurrentGameDueToStall', () => {
 
     expect(stopFarmingCalled).toBe(true);
     expect(stopParams?.stopReason).toBe('stall-skipped');
-    expect(stopParams?.notification.title).toBe('Farming stopped');
+    expect(stopParams?.notification.title).toBe('Farming stopped: no drop progress');
+    expect(stopParams?.notification.message).toContain('opened a stream but drop progress did not resume');
   });
 
   test('calls onSaveState after skipping', async () => {
@@ -1096,10 +1322,10 @@ describe('rotateStreamer', () => {
     expect(state.noProgressRotationAttempts).toBe(1);
   });
 
-  test('increments noProgressRotationAttempts for open-failed reason', async () => {
+  test('does not increment noProgressRotationAttempts for open-failed reason', async () => {
     const state = createMinimalState({ noProgressRotationAttempts: 0 });
     await rotateStreamer(state, 'open-failed', {});
-    expect(state.noProgressRotationAttempts).toBe(1);
+    expect(state.noProgressRotationAttempts).toBe(0);
   });
 
   test('does not increment for other rotation reasons', async () => {
@@ -1110,7 +1336,7 @@ describe('rotateStreamer', () => {
     expect(state.noProgressRotationAttempts).toBe(0);
   });
 
-  test('enters persistent recovery when max attempts reached', async () => {
+  test('does not enter persistent recovery for stalled progress because stalled flow has its own cap', async () => {
     const state = createMinimalState({ noProgressRotationAttempts: 3 });
 
     let enterRecoveryCalled = false;
@@ -1120,10 +1346,10 @@ describe('rotateStreamer', () => {
       },
     });
 
-    expect(enterRecoveryCalled).toBe(true);
+    expect(enterRecoveryCalled).toBe(false);
   });
 
-  test('forwards skip callback when stalled-progress enters persistent recovery', async () => {
+  test('does not forward skip callback through persistent recovery for stalled progress', async () => {
     const state = createMinimalState({ noProgressRotationAttempts: 3 });
     const skipCurrentGame = async () => {};
 
@@ -1135,10 +1361,10 @@ describe('rotateStreamer', () => {
       onSkipCurrentGame: skipCurrentGame,
     });
 
-    expect(forwardedSkip).toBe(skipCurrentGame);
+    expect(forwardedSkip).toBeUndefined();
   });
 
-  test('returns false when entering persistent recovery', async () => {
+  test('returns false when stalled rotation has no replacement streamer', async () => {
     const state = createMinimalState({ noProgressRotationAttempts: 3 });
 
     const result = await rotateStreamer(state, 'stalled-progress', {
@@ -1146,6 +1372,21 @@ describe('rotateStreamer', () => {
     });
 
     expect(result).toBe(false);
+  });
+
+  test('skips as stalled progress when a stalled rotation cannot open a replacement', async () => {
+    const state = createMinimalState({ stalledRecoveryAttempts: 2 });
+
+    let skipCalled = false;
+    await rotateStreamer(state, 'stalled-progress', {
+      onOpenStreamer: async () => false,
+      onSkipCurrentGame: async () => {
+        skipCalled = true;
+      },
+    });
+
+    expect(skipCalled).toBe(true);
+    expect(state.appState.recoveryReason).not.toBe('no-streamers');
   });
 
   test('sets rotation timestamps', async () => {
@@ -1208,17 +1449,17 @@ describe('rotateStreamer', () => {
     expect(result).toBe(false);
   });
 
-  test('increments attempts when open fails and reason does not count', async () => {
+  test('does not increment no-progress attempts when opening a replacement fails', async () => {
     const state = createMinimalState({ noProgressRotationAttempts: 0 });
 
     await rotateStreamer(state, 'offline', {
       onOpenStreamer: async () => false,
     });
 
-    expect(state.noProgressRotationAttempts).toBe(1);
+    expect(state.noProgressRotationAttempts).toBe(0);
   });
 
-  test('enters recovery when open fails and max attempts reached', async () => {
+  test('does not enter persistent recovery when a non-stall replacement fails to open', async () => {
     const state = createMinimalState({ noProgressRotationAttempts: 3 });
 
     let enterRecoveryCalled = false;
@@ -1229,10 +1470,10 @@ describe('rotateStreamer', () => {
       },
     });
 
-    expect(enterRecoveryCalled).toBe(true);
+    expect(enterRecoveryCalled).toBe(false);
   });
 
-  test('forwards skip callback when open failure enters persistent recovery', async () => {
+  test('does not forward skip callback through persistent recovery for non-stall open failures', async () => {
     const state = createMinimalState({ noProgressRotationAttempts: 3 });
     const skipCurrentGame = async () => {};
 
@@ -1245,7 +1486,7 @@ describe('rotateStreamer', () => {
       onSkipCurrentGame: skipCurrentGame,
     });
 
-    expect(forwardedSkip).toBe(skipCurrentGame);
+    expect(forwardedSkip).toBeUndefined();
   });
 
   test('calls onSaveState', async () => {
@@ -1289,6 +1530,20 @@ describe('rotateStreamer', () => {
 
     expect(saveTimingCalled).toBe(true);
   });
+
+  test('caps stalled progress retry attempts without entering persistent recovery', async () => {
+    const state = createMinimalState({ noProgressRotationAttempts: MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS });
+
+    let enterRecoveryCalled = false;
+    await rotateStreamer(state, 'stalled-progress', {
+      onEnterPersistentRecovery: async () => {
+        enterRecoveryCalled = true;
+      },
+    });
+
+    expect(state.noProgressRotationAttempts).toBe(MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS);
+    expect(enterRecoveryCalled).toBe(false);
+  });
 });
 
 describe('checkDropProgress', () => {
@@ -1321,6 +1576,7 @@ describe('checkDropProgress', () => {
       onEnforcePlaybackPolicy: async () => {
         calls.push('playback-policy');
       },
+      onAcquireStreamerForSelectedGame: async () => false,
       onRefreshDropsData: async () => {
         calls.push('refresh-drops');
         state.lastProgressAdvanceAt = Date.now();
@@ -1375,6 +1631,7 @@ describe('checkDropProgress', () => {
 
     await checkDropProgress(state, {
       onEnforcePlaybackPolicy: async () => undefined,
+      onAcquireStreamerForSelectedGame: async () => false,
       onRefreshDropsData: async (opts) => {
         refreshOptions.push(opts);
       },
@@ -1386,6 +1643,117 @@ describe('checkDropProgress', () => {
     });
 
     expect(refreshOptions[0]).toEqual({ includeCampaignFetch: true, includeInventoryFetch: true });
+  });
+
+  test('does not validate the old tab while no-streamers retry backoff is active', async () => {
+    const state = createMinimalState();
+    state.appState.isRunning = true;
+    state.appState.selectedGame = createGame({ name: 'No Live Game' });
+    state.appState.tabId = 123;
+    state.appState.recoveryReason = 'no-streamers';
+    state.appState.recoveryAttempts = 1;
+    state.recoveryBackoffUntil = Date.now() + 60_000;
+
+    let playbackPolicyCalls = 0;
+    let validationCalls = 0;
+    let acquisitionCalls = 0;
+
+    await checkDropProgress(state, {
+      onEnforcePlaybackPolicy: async () => {
+        playbackPolicyCalls += 1;
+      },
+      onRotateStreamerIfInvalid: async () => {
+        validationCalls += 1;
+      },
+      onAcquireStreamerForSelectedGame: async () => {
+        acquisitionCalls += 1;
+        return false;
+      },
+      onRefreshDropsData: async () => undefined,
+      onAttemptAutoClaimChannelPointsBonus: async () => false,
+      onAutoClaimClaimableDrops: async () => false,
+      onAdvanceQueueIfCompleted: async () => true,
+      onSaveTimingState: async () => undefined,
+    });
+
+    expect(playbackPolicyCalls).toBe(0);
+    expect(validationCalls).toBe(0);
+    expect(acquisitionCalls).toBe(0);
+    expect(state.appState.tabId).toBe(123);
+  });
+
+  test('retries streamer acquisition directly when no-streamers backoff expires', async () => {
+    const state = createMinimalState();
+    state.appState.isRunning = true;
+    state.appState.selectedGame = createGame({ name: 'No Live Game' });
+    state.appState.tabId = 123;
+    state.appState.recoveryReason = 'no-streamers';
+    state.appState.recoveryAttempts = 1;
+    state.recoveryBackoffUntil = Date.now() - 1;
+
+    let validationCalls = 0;
+    let acquisitionCalls = 0;
+
+    await checkDropProgress(state, {
+      onEnforcePlaybackPolicy: async () => undefined,
+      onRotateStreamerIfInvalid: async () => {
+        validationCalls += 1;
+      },
+      onAcquireStreamerForSelectedGame: async () => {
+        acquisitionCalls += 1;
+        return false;
+      },
+      onRefreshDropsData: async () => undefined,
+      onAttemptAutoClaimChannelPointsBonus: async () => false,
+      onAutoClaimClaimableDrops: async () => false,
+      onAdvanceQueueIfCompleted: async () => true,
+      onSaveTimingState: async () => undefined,
+    });
+
+    expect(validationCalls).toBe(0);
+    expect(acquisitionCalls).toBe(1);
+  });
+});
+
+describe('openBestStreamerForSelectedGame', () => {
+  test('preserves managed tab id when no streamer is found so the next game can reuse it', async () => {
+    const state = createMinimalState();
+    state.appState.selectedGame = createGame({ name: 'No Live Game' });
+    state.appState.tabId = 123;
+    state.appState.activeStreamer = {
+      id: 'old-streamer',
+      name: 'old-streamer',
+      displayName: 'Old Streamer',
+      isLive: true,
+    };
+
+    const opened = await openBestStreamerForSelectedGame(
+      state,
+      {
+        onFetchDirectoryStreamersFromApi: async () =>
+          Object.assign([], { languageFilterApplied: false }) as never,
+        onOpenForegroundChannel: async () => {
+          throw new Error('should not open a channel without candidates');
+        },
+      },
+      {
+        dropMatchesSelectedGame: () => true,
+        isDropCompleted: () => false,
+        getGameDisplayLabel: (item) => item.name,
+        resolveCategorySlug: async () => 'no-live-game',
+        pickStreamerForPreferences: () => ({
+          streamer: null,
+          activePoolSize: 0,
+          preferredLanguageApplied: false,
+          preferredLanguageMatches: 0,
+        }),
+        normalizePreferredStreamerLanguage: () => null,
+      },
+    );
+
+    expect(opened).toBe(false);
+    expect(state.appState.tabId).toBe(123);
+    expect(state.appState.activeStreamer).toBeNull();
   });
 });
 
@@ -1839,10 +2207,12 @@ describe('rotateStreamerIfInvalid', () => {
     });
 
     expect(attemptSelfHealCalled).toBe(true);
-    expect(state.stalledRecoveryAttempts).toBeGreaterThan(0);
+    expect(state.stalledRecoveryAttempts).toBe(1);
+    expect(state.appState.recoveryReason).toBe('stalled-progress');
+    expect(state.appState.recoveryAttempts).toBe(1);
   });
 
-  test('rotates when stalled and past recovery backoff', async () => {
+  test('rotates with a bounded stalled attempt count when past recovery backoff', async () => {
     const state = createMinimalState();
     state.appState.selectedGame = createGame({ name: 'Test Game', categorySlug: 'test-game' });
     state.appState.tabId = 123;
@@ -1876,15 +2246,17 @@ describe('rotateStreamerIfInvalid', () => {
     });
 
     expect(rotateReason).toBe('stalled-progress');
+    expect(state.stalledRecoveryAttempts).toBe(3);
+    expect(state.appState.recoveryAttempts).toBe(3);
   });
 
-  test('skips current game when stalled recovery cycles are exhausted', async () => {
+  test('skips current game when stalled progress reaches the human attempt cap', async () => {
     const state = createMinimalState();
     state.appState.selectedGame = createGame({ name: 'Test Game', categorySlug: 'test-game' });
     state.appState.tabId = 123;
     state.appState.currentDrop = createDrop({ requiredMinutes: 60 });
     state.lastProgressAdvanceAt = Date.now() - 10 * 60 * 1000;
-    state.stalledRecoveryAttempts = 6;
+    state.stalledRecoveryAttempts = MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS;
     state.lastStreamRotationAt = 0;
 
     mocks.tabs.setTabsGetResult({ id: 123, url: 'https://twitch.tv/streamer' });

--- a/tests/queue-management.test.ts
+++ b/tests/queue-management.test.ts
@@ -13,10 +13,13 @@ import {
   advanceQueueIfCompleted,
   skipCurrentGameDueToStall,
   handleStartFarming,
+  refreshDropsData,
   rotateStreamer,
   rotateStreamerIfInvalid,
   checkDropProgress,
 } from '../src/background/queue-management.ts';
+import { splitDropsForSelectedGame, updateStateFromSnapshot } from '../src/background/drop-processing.ts';
+import { replaceAvailableGames } from '../src/shared/game-selection.ts';
 import type { ServiceWorkerState } from '../src/background/service-worker.ts';
 import { createInitialState } from '../src/shared/utils.ts';
 import type { TwitchGame, TwitchDrop } from '../src/types/index.ts';
@@ -1356,6 +1359,189 @@ describe('checkDropProgress', () => {
     expect(calls).toEqual(['playback-policy', 'refresh-drops', 'validate-stream']);
     expect(attemptSelfHealCalled).toBe(false);
     expect(rotateReason).toBeNull();
+  });
+
+  test('requests a full campaign refresh when the full tick interval elapses', async () => {
+    const state = createMinimalState();
+    state.appState.isRunning = true;
+    state.appState.selectedGame = createGame({ name: 'Test Game', categorySlug: 'test-game' });
+    state.lastFullRefreshAt = Date.now() - 3 * 60 * 1000;
+
+    const refreshOptions: Array<{
+      includeCampaignFetch?: boolean;
+      includeInventoryFetch?: boolean;
+      forceInventoryFetch?: boolean;
+    } | undefined> = [];
+
+    await checkDropProgress(state, {
+      onEnforcePlaybackPolicy: async () => undefined,
+      onRefreshDropsData: async (opts) => {
+        refreshOptions.push(opts);
+      },
+      onRotateStreamerIfInvalid: async () => undefined,
+      onAttemptAutoClaimChannelPointsBonus: async () => false,
+      onAutoClaimClaimableDrops: async () => false,
+      onAdvanceQueueIfCompleted: async () => true,
+      onSaveTimingState: async () => undefined,
+    });
+
+    expect(refreshOptions[0]).toEqual({ includeCampaignFetch: true, includeInventoryFetch: true });
+  });
+});
+
+describe('refreshDropsData light refresh', () => {
+  test('updates inventory progress without calling the full campaign fetch', async () => {
+    const state = createMinimalState();
+    const forHonor = createGame({
+      id: 'campaign-for-honor',
+      name: 'For Honor',
+      campaignId: 'campaign-for-honor',
+      categorySlug: 'for-honor',
+    });
+    const overwatch = createGame({
+      id: 'campaign-overwatch',
+      name: 'Overwatch',
+      campaignId: 'campaign-overwatch',
+      categorySlug: 'overwatch',
+    });
+    const forHonorDrop = createDrop({
+      id: 'drop-for-honor',
+      gameId: forHonor.id,
+      gameName: forHonor.name,
+      campaignId: forHonor.campaignId,
+      currentMinutes: 120,
+      requiredMinutes: 240,
+      remainingMinutes: 120,
+      progress: 50,
+    });
+    const overwatchDrop = createDrop({
+      id: 'drop-overwatch',
+      gameId: overwatch.id,
+      gameName: overwatch.name,
+      campaignId: overwatch.campaignId,
+      currentMinutes: 327,
+      requiredMinutes: 720,
+      remainingMinutes: 393,
+      progress: 45,
+    });
+
+    state.appState.isRunning = true;
+    state.appState.selectedGame = forHonor;
+    state.appState.availableGames = [forHonor, overwatch];
+    state.appState.queue = [forHonor, overwatch];
+    state.cachedDropsSnapshot = [forHonorDrop, overwatchDrop];
+    splitDropsForSelectedGame(state, state.cachedDropsSnapshot);
+
+    let fullFetchCalled = false;
+    let inventoryFetchCalled = false;
+
+    await refreshDropsData(
+      state,
+      { includeInventoryFetch: true },
+      {
+        onFetchDropsSnapshotFromApi: async () => {
+          fullFetchCalled = true;
+          return null;
+        },
+        onFetchInventorySnapshotFromApi: async (baseDrops) => {
+          inventoryFetchCalled = true;
+          return {
+            games: [],
+            drops: baseDrops.map((drop) =>
+              drop.campaignId === forHonor.campaignId
+                ? { ...drop, currentMinutes: 180, progress: 75, remainingMinutes: 60 }
+                : drop,
+            ),
+            updatedAt: Date.now(),
+          };
+        },
+        onEvaluateDropTransitions: async () => undefined,
+        onSaveState: async () => undefined,
+      },
+      {
+        replaceAvailableGames,
+        getGameDisplayLabel: (game) => game.displayName ?? game.name,
+        updateStateFromSnapshot,
+        normalizeQueueSelection,
+      },
+    );
+
+    expect(fullFetchCalled).toBe(false);
+    expect(inventoryFetchCalled).toBe(true);
+    expect(state.appState.selectedGame?.campaignId).toBe(forHonor.campaignId);
+    expect(state.appState.currentDrop?.campaignId).toBe(forHonor.campaignId);
+    expect(state.appState.currentDrop?.currentMinutes).toBe(180);
+    expect(state.appState.queue.map((game) => game.campaignId)).toEqual([
+      forHonor.campaignId,
+      overwatch.campaignId,
+    ]);
+  });
+
+  test('preserves cached cross-game drops when inventory-only refresh has no data', async () => {
+    const state = createMinimalState();
+    const forHonor = createGame({
+      id: 'campaign-for-honor',
+      name: 'For Honor',
+      campaignId: 'campaign-for-honor',
+      categorySlug: 'for-honor',
+    });
+    const overwatch = createGame({
+      id: 'campaign-overwatch',
+      name: 'Overwatch',
+      campaignId: 'campaign-overwatch',
+      categorySlug: 'overwatch',
+    });
+    const forHonorDrop = createDrop({
+      id: 'drop-for-honor',
+      gameId: forHonor.id,
+      gameName: forHonor.name,
+      campaignId: forHonor.campaignId,
+      currentMinutes: 120,
+      requiredMinutes: 240,
+      remainingMinutes: 120,
+      progress: 50,
+    });
+    const overwatchDrop = createDrop({
+      id: 'drop-overwatch',
+      gameId: overwatch.id,
+      gameName: overwatch.name,
+      campaignId: overwatch.campaignId,
+      claimId: 'claim-overwatch',
+      claimable: true,
+      currentMinutes: 60,
+      requiredMinutes: 60,
+      remainingMinutes: 0,
+      progress: 100,
+    });
+
+    state.appState.isRunning = true;
+    state.appState.selectedGame = forHonor;
+    state.appState.availableGames = [forHonor, overwatch];
+    state.appState.queue = [forHonor, overwatch];
+    state.cachedDropsSnapshot = [forHonorDrop, overwatchDrop];
+    splitDropsForSelectedGame(state, state.cachedDropsSnapshot);
+
+    await refreshDropsData(
+      state,
+      { includeInventoryFetch: true },
+      {
+        onFetchDropsSnapshotFromApi: async () => null,
+        onFetchInventorySnapshotFromApi: async () => null,
+        onEvaluateDropTransitions: async () => undefined,
+        onSaveState: async () => undefined,
+      },
+      {
+        replaceAvailableGames,
+        getGameDisplayLabel: (game) => game.displayName ?? game.name,
+        updateStateFromSnapshot,
+        normalizeQueueSelection,
+      },
+    );
+
+    expect(state.appState.selectedGame?.campaignId).toBe(forHonor.campaignId);
+    expect(state.appState.currentDrop?.campaignId).toBe(forHonor.campaignId);
+    expect(state.cachedDropsSnapshot.map((drop) => drop.id)).toEqual(['drop-for-honor', 'drop-overwatch']);
+    expect(state.cachedDropsSnapshot.find((drop) => drop.id === 'drop-overwatch')?.claimable).toBe(true);
   });
 });
 

--- a/tests/release-check-ui.test.ts
+++ b/tests/release-check-ui.test.ts
@@ -109,6 +109,37 @@ describe('release check UI runner', () => {
     expect(output.text()).toContain('src/file.ts:1:1 error TS2304');
   });
 
+  test('summarizes huge bun test failures without dumping the whole log', async () => {
+    const output = createOutput();
+    const noise = Array.from({ length: 80 }, (_value, index) => `(pass) noise test ${index}`).join('\n');
+
+    await runSteps([{ name: 'Tests', command: ['bun', 'run', 'test'] }], {
+      write: output.write,
+      executor: async () => ({
+        exitCode: 1,
+        stdout: 'bun test v1.3.13\n',
+        stderr: `${noise}
+(fail) queue management > skips game after stalled recovery [2.14ms]
+1096 |     expect(result).toBe(true)
+                         ^
+error: expect(received).toBe(expected)
+Expected: true
+Received: false
+    at /Users/djtrevo/repos/drophunter/tests/queue-management.test.ts:1096:22
+${noise}
+`,
+      }),
+      isInteractive: false,
+    });
+
+    expect(output.text()).toContain('Error summary');
+    expect(output.text()).toContain('tests/queue-management.test.ts:1096:22');
+    expect(output.text()).toContain('(fail) queue management > skips game after stalled recovery');
+    expect(output.text()).toContain('Expected: true');
+    expect(output.text()).toContain('Received: false');
+    expect(output.text()).not.toContain('(pass) noise test 79');
+  });
+
   test('marks warning output without failing the release check', async () => {
     const output = createOutput();
 

--- a/tests/runtime-status.test.ts
+++ b/tests/runtime-status.test.ts
@@ -5,6 +5,7 @@ import {
   clearRecoveryStatus,
   clearTerminalStopStatus,
   deriveRuntimeMode,
+  formatRecoveryAttemptLabel,
   formatRecoveryReason,
   formatRetryLabel,
   formatRotationReason,
@@ -133,8 +134,19 @@ describe('runtime status selectors', () => {
 describe('runtime status formatting', () => {
   test('formats rotation and recovery reasons for the UI', () => {
     expect(formatRotationReason('drops-inactive')).toBe('Drops signal missing');
-    expect(formatRotationReason('open-failed')).toBe('Reopened stream');
+    expect(formatRotationReason('open-failed')).toBe('Could not open stream');
+    expect(formatRotationReason('no-streamers')).toBe('No live streamers found');
     expect(formatRecoveryReason('drops-inactive')).toBe('Recovering missing drops signal');
+    expect(formatRecoveryReason('open-failed')).toBe('Could not open stream');
+    expect(formatRecoveryReason('no-streamers')).toBe('No live streamers found');
+    expect(formatRecoveryReason('stalled-progress')).toBe('Checking stalled drop progress');
+  });
+
+  test('formats stalled-progress attempts with a visible cap', () => {
+    expect(formatRecoveryAttemptLabel('stalled-progress', 1)).toBe('attempt 1/3');
+    expect(formatRecoveryAttemptLabel('stalled-progress', 4)).toBe('attempt 3/3');
+    expect(formatRecoveryAttemptLabel('no-streamers', 1)).toBeNull();
+    expect(formatRecoveryAttemptLabel('stalled-progress', null)).toBeNull();
   });
 
   test('formats retry label only for future timestamps', () => {

--- a/tests/service-worker.test.ts
+++ b/tests/service-worker.test.ts
@@ -284,11 +284,11 @@ function installFetchMock() {
       }
 
       case 'Inventory': {
-        const scenario = activeSnapshotScenario;
+        const scenario = activeSnapshotScenario ?? snapshotQueue.shift();
         if (!scenario) {
           throw new Error('Unexpected inventory fetch in service-worker test');
         }
-        if (scenario.drops.length === 0) {
+        if (activeSnapshotScenario && scenario.drops.length === 0) {
           activeSnapshotScenario = null;
         }
         return jsonResponse({

--- a/tests/service-worker.test.ts
+++ b/tests/service-worker.test.ts
@@ -472,6 +472,7 @@ describe('service worker message handlers', () => {
 
   afterAll(async () => {
     await sleepTick();
+    setTimingSaveDebounceMsForTests(null);
     chromeMocks.teardown();
   });
 
@@ -991,6 +992,86 @@ describe('service worker message handlers', () => {
 
     expect(state.selectedGame?.campaignId).toBe(nextGame.campaignId);
     expect(state.queue.map((game) => game.name)).toEqual([nextGame.name, thirdGame.name]);
+  });
+
+  test('completes the queue when the last queued game has no live streamers after retry', async () => {
+    const realDateNow = Date.now;
+    let now = realDateNow();
+    Date.now = () => now;
+
+    const notifications: Array<{ title: string; message: string }> = [];
+    const chromeAny = (globalThis as unknown as { chrome: Record<string, any> }).chrome;
+    const originalCreateNotification = chromeAny.notifications.create;
+    chromeAny.notifications.create = async ({ title, message }: { title: string; message: string }) => {
+      notifications.push({ title, message });
+      return 'notification-id';
+    };
+
+    try {
+      enqueueDropsSnapshot([{ game: demoGame, dropId: 'drop-current', currentMinutes: 0 }]);
+      enqueueDirectoryResult(null);
+      enqueueDirectoryResult(null);
+      enqueueDropsSnapshot([{ game: nextGame, dropId: 'drop-next', currentMinutes: 0 }]);
+      enqueueDirectoryResult(null);
+      enqueueDirectoryResult(null);
+
+      await syncTestSession();
+      chromeMocks.permissions.setContainsResult(true);
+      await dispatchMessage({
+        type: 'SET_NOTIFICATIONS_ENABLED',
+        payload: { enabled: true },
+      });
+      await addGameToQueue(nextGame);
+
+      const startResponse = await dispatchMessage({
+        type: 'START_FARMING',
+        payload: { game: demoGame },
+      });
+
+      expect(startResponse).toEqual({ success: true });
+      await waitForAppState(
+        (state) =>
+          state.isRunning &&
+          state.selectedGame?.campaignId === demoGame.campaignId &&
+          state.recoveryReason === 'no-streamers',
+        'first no-streamers retry was not scheduled',
+      );
+
+      now += 61_000;
+      await triggerMonitorAlarm();
+      await waitForAppState(
+        (state) =>
+          state.isRunning &&
+          state.selectedGame?.campaignId === nextGame.campaignId &&
+          state.recoveryReason === 'no-streamers',
+        'queue did not advance to the second game and schedule its no-streamers retry',
+      );
+      for (let i = 0; i < 5; i += 1) {
+        await sleepTick();
+      }
+
+      now += 61_000;
+      await triggerMonitorAlarm();
+      const finalState = await waitForAppState(
+        (state) => !state.isRunning && state.lastStopReason === 'queue-complete',
+        'queue did not complete after the last no-streamers retry failed',
+      );
+
+      expect(finalState.isPaused).toBe(false);
+      expect(finalState.selectedGame).toBeNull();
+      expect(finalState.activeStreamer).toBeNull();
+      expect(finalState.tabId).toBeNull();
+      expect(finalState.queue).toEqual([]);
+      expect(finalState.recoveryReason).toBeNull();
+      expect(finalState.recoveryBackoffUntil).toBeNull();
+      expect(finalState.recoveryAttempts).toBeNull();
+      expect(finalState.lastStopMessage).toContain('Queue completed');
+      expect(finalState.lastStopMessage).toContain('No live streamers found');
+      expect(notifications.some((notification) => notification.title === 'Queue completed')).toBe(true);
+    } finally {
+      Date.now = realDateNow;
+      chromeAny.notifications.create = originalCreateNotification;
+    }
   });
 
   test('normalizeGameSelection clears selectedGame when exact campaign no longer exists', async () => {

--- a/tests/stream-rotation.test.ts
+++ b/tests/stream-rotation.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, test } from 'bun:test';
 import {
   classifyStreamHealth,
   computeRecoveryBackoffMs,
+  NO_STREAMERS_RETRY_MS,
   detectRecoveryProof,
   MAX_NO_PROGRESS_ROTATION_ATTEMPTS,
   MAX_PERSISTENT_RECOVERY_CYCLES,
+  MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS,
   MAX_RECOVERY_BACKOFF_MS,
   RECOVERY_BACKOFF_BASE_MS,
+  STALLED_PROGRESS_RETRY_MS,
   didDropProgressAdvance,
   didDropMinutesAdvance,
   computeEffectiveStallThreshold,
@@ -59,9 +62,10 @@ test('recovery proof is not detected when the active drop changed without new co
   ).toBe(false);
 });
 
-test('only stalled rotations and open failures increment retry attempts', () => {
+test('only stalled rotations increment no-progress retry attempts', () => {
   expect(shouldIncrementNoProgressRotationAttempts('stalled-progress')).toBe(true);
-  expect(shouldIncrementNoProgressRotationAttempts('open-failed')).toBe(true);
+  expect(shouldIncrementNoProgressRotationAttempts('open-failed')).toBe(false);
+  expect(shouldIncrementNoProgressRotationAttempts('no-streamers')).toBe(false);
   expect(shouldIncrementNoProgressRotationAttempts('offline')).toBe(false);
   expect(shouldIncrementNoProgressRotationAttempts('wrong-channel')).toBe(false);
   expect(shouldIncrementNoProgressRotationAttempts('wrong-game')).toBe(false);
@@ -72,7 +76,7 @@ test('retry attempts stop at the configured cap', () => {
   let attempts = 0;
   attempts = nextNoProgressRotationAttempts(attempts, 'stalled-progress');
   attempts = nextNoProgressRotationAttempts(attempts, 'stalled-progress');
-  attempts = nextNoProgressRotationAttempts(attempts, 'open-failed');
+  attempts = nextNoProgressRotationAttempts(attempts, 'stalled-progress');
   expect(attempts).toBe(MAX_NO_PROGRESS_ROTATION_ATTEMPTS);
 
   attempts = nextNoProgressRotationAttempts(attempts, 'stalled-progress');
@@ -88,7 +92,18 @@ test('recovery backoff grows exponentially and caps at the configured maximum', 
 
 test('offline rotations keep the current retry count unchanged', () => {
   expect(nextNoProgressRotationAttempts(2, 'offline')).toBe(2);
+  expect(nextNoProgressRotationAttempts(2, 'open-failed')).toBe(2);
+  expect(nextNoProgressRotationAttempts(2, 'no-streamers')).toBe(2);
   expect(nextNoProgressRotationAttempts(2, 'missing-context')).toBe(2);
+});
+
+test('no streamer retry window is exactly one minute', () => {
+  expect(NO_STREAMERS_RETRY_MS).toBe(60_000);
+});
+
+test('stalled progress recovery is capped to three human-readable attempts', () => {
+  expect(MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS).toBe(3);
+  expect(STALLED_PROGRESS_RETRY_MS).toBe(60_000);
 });
 
 test('healthy live stream with matching game and drops signal does not request recovery', () => {


### PR DESCRIPTION
## Summary
- split no-streamers acquisition from stalled drop recovery
- cap stalled drop recovery at three visible attempts with clear skip/stop copy
- preserve managed Twitch tabs for reuse and add strict extension-page CSP

## Review
- Checked Chrome extension MV3/service-worker/security guidance: persisted recovery state, no broad host permissions, no eval/inline HTML sinks, explicit CSP, HTTPS-only Twitch host access.
- Checked React/Vercel-style UI guidance: countdown state only ticks while recovering, no new data waterfalls, no new dependencies, and no bundle-heavy UI changes.

## Validation
- bun audit
- bun run check