### PR TITLE
Harden drop recovery logic

### DIFF
--- a/src/background/api-operations.ts
+++ b/src/background/api-operations.ts
@@ -61,6 +61,9 @@ export async function fetchDropsSnapshotFromApi(
         return fallbackSnapshot;
       } catch {}
     }
+    if (isLikelyAuthError(error)) {
+      throw error;
+    }
     state.apiConsecutiveFailures += 1;
     state.apiBackoffUntil =
       Date.now() + Math.min(2 ** state.apiConsecutiveFailures * PROGRESS_POLL_MS, 10 * 60_000);
@@ -116,6 +119,9 @@ export async function fetchInventorySnapshotFromApi(
         return fallbackSnapshot.drops.length > 0 ? fallbackSnapshot : null;
       } catch {}
     }
+    if (isLikelyAuthError(error)) {
+      throw error;
+    }
     state.apiConsecutiveFailures += 1;
     state.apiBackoffUntil =
       Date.now() + Math.min(2 ** state.apiConsecutiveFailures * PROGRESS_POLL_MS, 10 * 60_000);
@@ -170,6 +176,31 @@ export interface FetchInventorySnapshotFromApiCallbacks {
   onEnsureTwitchSession: (forceRefresh?: boolean) => Promise<TwitchSession | null>;
   onIsLikelyAuthError: (error: unknown) => boolean;
   onClearTwitchSessionCache: (state: ServiceWorkerState) => void;
+  onStopFarmingSession?: (options: {
+    notification?: { title: string; message: string };
+    stopReason?: string;
+    stopMessage?: string | null;
+  }) => Promise<void>;
+}
+
+const SIGN_IN_REQUIRED_MESSAGE =
+  'DropHunter could not refresh your Twitch session. Please open Twitch and sign in.';
+
+async function stopForSignInRequiredIfRunning(
+  state: ServiceWorkerState,
+  callback?: FetchDropsSnapshotFromApiCallbacks['onStopFarmingSession'],
+) {
+  if (!state.appState.isRunning || !callback) {
+    return;
+  }
+  await callback({
+    notification: {
+      title: 'Sign-in required',
+      message: SIGN_IN_REQUIRED_MESSAGE,
+    },
+    stopReason: 'sign-in-required',
+    stopMessage: SIGN_IN_REQUIRED_MESSAGE,
+  });
 }
 
 export async function fetchInventorySnapshotFromApiWrapper(
@@ -184,6 +215,9 @@ export async function fetchInventorySnapshotFromApiWrapper(
   const session = await callbacks.onEnsureTwitchSession(forceSessionRefresh);
   if (!session) {
     deps.logWarn('Inventory snapshot API skipped: Twitch session missing');
+    if (forceSessionRefresh) {
+      await stopForSignInRequiredIfRunning(state, callbacks.onStopFarmingSession);
+    }
     return null;
   }
 
@@ -195,6 +229,9 @@ export async function fetchInventorySnapshotFromApiWrapper(
       if (!forceSessionRefresh) {
         return fetchInventorySnapshotFromApiWrapper(state, baseDrops, true, callbacks, deps);
       }
+      deps.logWarn('Twitch inventory auth failed after forced session refresh:', String(error));
+      await stopForSignInRequiredIfRunning(state, callbacks.onStopFarmingSession);
+      return null;
     }
     deps.logWarn('Twitch inventory snapshot fetch failed:', String(error));
     return null;
@@ -217,6 +254,9 @@ export async function fetchDropsSnapshotFromApiWrapper(
   let session = await callbacks.onEnsureTwitchSession(forceSessionRefresh);
   if (!session) {
     deps.logWarn('Drops snapshot API skipped: Twitch session missing');
+    if (forceSessionRefresh) {
+      await stopForSignInRequiredIfRunning(state, callbacks.onStopFarmingSession);
+    }
     return null;
   }
   if (!session.userId) {
@@ -264,6 +304,9 @@ export async function fetchDropsSnapshotFromApiWrapper(
       if (!forceSessionRefresh) {
         return fetchDropsSnapshotFromApiWrapper(state, true, callbacks, deps);
       }
+      deps.logWarn('Twitch API auth failed after forced session refresh:', String(error));
+      await stopForSignInRequiredIfRunning(state, callbacks.onStopFarmingSession);
+      return null;
     }
     deps.logWarn('Twitch API snapshot fetch failed:', String(error));
     state.apiConsecutiveFailures += 1;

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -1,4 +1,9 @@
-import { assertNever, isRuntimeRequest, type RuntimeRequest } from '../shared/messages.ts';
+import {
+  assertNever,
+  isRuntimeMessageType,
+  isRuntimeRequest,
+  type RuntimeRequest,
+} from '../shared/messages.ts';
 
 type MaybePromise<T> = T | Promise<T>;
 type RuntimeSender = chrome.runtime.MessageSender;
@@ -59,8 +64,13 @@ function unsupportedTarget(sendResponse: RuntimeSendResponse) {
 
 export function createRuntimeMessageListener(handlers: RuntimeMessageHandlers): RuntimeMessageListener {
   return (message: unknown, sender, sendResponse) => {
-    if (!isRuntimeRequest(message)) {
+    const type = message && typeof message === 'object' ? (message as { type?: unknown }).type : undefined;
+    if (!isRuntimeMessageType(type)) {
       sendResponse({ success: false, error: 'Unknown message type' });
+      return true;
+    }
+    if (!isRuntimeRequest(message)) {
+      sendResponse({ success: false, error: 'Invalid message payload' });
       return true;
     }
 

--- a/src/background/queue-management.ts
+++ b/src/background/queue-management.ts
@@ -28,7 +28,6 @@ import {
   MAX_STALLED_PROGRESS_RECOVERY_ATTEMPTS,
   NO_STREAMERS_RETRY_MS,
   nextNoProgressRotationAttempts,
-  PROGRESS_STALL_THRESHOLD_MS,
   STALLED_PROGRESS_RETRY_MS,
   StreamRotationReason,
 } from './stream-rotation';
@@ -44,16 +43,6 @@ const STREAM_ROTATE_COOLDOWN_MS = 5 * 60_000;
 
 function queueContainsGame(state: ServiceWorkerState, game: TwitchGame): boolean {
   return state.appState.queue.some((queuedGame) => isSameGame(queuedGame, game));
-}
-
-async function notify(title: string, message: string, priority = 2) {
-  await chrome.notifications.create({
-    type: 'basic',
-    iconUrl: 'icons/icon128.png',
-    title,
-    message,
-    priority,
-  });
 }
 
 function resetNoProgressRotationAttempts(state: ServiceWorkerState) {
@@ -97,6 +86,27 @@ function applyNoStreamersRecoveryState(state: ServiceWorkerState, retryAt: numbe
     retryAt,
     attempts,
   });
+}
+
+function shouldKeepStreamerWhileDropProgresses(input: {
+  currentDrop: TwitchDrop | null;
+  lastProgressAdvanceAt: number;
+  now: number;
+  effectiveThresholdMs: number;
+  reason: StreamRotationReason | null;
+}): boolean {
+  const fatalReason =
+    input.reason === 'offline' ||
+    input.reason === 'navigated-away' ||
+    input.reason === 'open-failed' ||
+    input.reason === 'no-streamers' ||
+    input.reason === 'stalled-progress';
+  return (
+    !fatalReason &&
+    input.currentDrop != null &&
+    input.lastProgressAdvanceAt > 0 &&
+    input.now - input.lastProgressAdvanceAt < input.effectiveThresholdMs
+  );
 }
 
 // ============================================================================
@@ -209,6 +219,7 @@ export async function enterPersistentRecovery(
   message: string,
   opts?: {
     onSkipCurrentGame?: () => Promise<void>;
+    onNotify?: (title: string, message: string, priority?: number) => Promise<void>;
   },
 ) {
   state.stalledRecoveryAttempts += 1;
@@ -232,7 +243,7 @@ export async function enterPersistentRecovery(
   });
   if (!state.recoveryNotificationSent) {
     state.recoveryNotificationSent = true;
-    await notify('DropHunter is still recovering', message, 1);
+    await opts?.onNotify?.('DropHunter is still recovering', message, 1);
   }
 }
 
@@ -549,6 +560,7 @@ export async function skipCurrentGameAndAdvanceQueue(
       stopMessage: string;
       notification: { title: string; message: string };
     }) => Promise<void>;
+    onNotify?: (title: string, message: string, priority?: number) => Promise<void>;
   },
 ) {
   const skippedGame = state.appState.selectedGame;
@@ -606,7 +618,7 @@ export async function skipCurrentGameAndAdvanceQueue(
     if (opts?.onOpenStreamer) {
       await opts.onOpenStreamer();
     }
-    await notify(
+    await opts?.onNotify?.(
       copy.skipNotificationTitle,
       `${copy.skipMessage} Now farming ${getGameDisplayLabel(nextGame)}.`,
     );
@@ -728,7 +740,10 @@ export async function rotateStreamer(
       state: ServiceWorkerState,
       reason: StreamRotationReason,
       message: string,
-      opts?: { onSkipCurrentGame?: () => Promise<void> },
+      opts?: {
+        onSkipCurrentGame?: () => Promise<void>;
+        onNotify?: (title: string, message: string, priority?: number) => Promise<void>;
+      },
     ) => Promise<void>;
     onSkipCurrentGame?: () => Promise<void>;
   },
@@ -786,7 +801,10 @@ export async function rotateStreamerIfInvalid(
           state: ServiceWorkerState,
           reason: StreamRotationReason,
           message: string,
-          opts?: { onSkipCurrentGame?: () => Promise<void> },
+          opts?: {
+            onSkipCurrentGame?: () => Promise<void>;
+            onNotify?: (title: string, message: string, priority?: number) => Promise<void>;
+          },
         ) => Promise<void>;
         onSkipCurrentGame?: () => Promise<void>;
       },
@@ -796,7 +814,10 @@ export async function rotateStreamerIfInvalid(
       state: ServiceWorkerState,
       reason: StreamRotationReason,
       message: string,
-      opts?: { onSkipCurrentGame?: () => Promise<void> },
+      opts?: {
+        onSkipCurrentGame?: () => Promise<void>;
+        onNotify?: (title: string, message: string, priority?: number) => Promise<void>;
+      },
     ) => Promise<void>;
     onSkipCurrentGame?: () => Promise<void>;
   },
@@ -855,10 +876,6 @@ export async function rotateStreamerIfInvalid(
     return;
   }
   const effectiveThreshold = computeEffectiveStallThreshold(state.appState.currentDrop?.requiredMinutes);
-  const dropProgressIsActive =
-    state.appState.currentDrop != null &&
-    state.lastProgressAdvanceAt > 0 &&
-    now - state.lastProgressAdvanceAt < effectiveThreshold;
 
   if (!context) {
     const tabUrl = tab.url ?? '';
@@ -866,7 +883,15 @@ export async function rotateStreamerIfInvalid(
     if (!isStillOnTwitch) {
       logInfo('Managed tab navigated away from Twitch', { tabUrl });
       state.invalidStreamChecks = INVALID_STREAM_THRESHOLD;
-    } else if (dropProgressIsActive) {
+    } else if (
+      shouldKeepStreamerWhileDropProgresses({
+        currentDrop: state.appState.currentDrop,
+        lastProgressAdvanceAt: state.lastProgressAdvanceAt,
+        now,
+        effectiveThresholdMs: effectiveThreshold,
+        reason: 'missing-context',
+      })
+    ) {
       logDebug('Stream context missing but drop progress is recent; keeping current streamer', {
         tabUrl,
         lastProgressAdvanceAt: state.lastProgressAdvanceAt,
@@ -988,7 +1013,15 @@ export async function rotateStreamerIfInvalid(
     return;
   }
 
-  if (dropProgressIsActive && health.reason !== 'stalled-progress') {
+  if (
+    shouldKeepStreamerWhileDropProgresses({
+      currentDrop: state.appState.currentDrop,
+      lastProgressAdvanceAt: state.lastProgressAdvanceAt,
+      now,
+      effectiveThresholdMs: effectiveThreshold,
+      reason: health.reason,
+    })
+  ) {
     logDebug('Stream validation failed but drop progress is active; keeping current streamer', {
       reason: health.reason,
       lastProgressAdvanceAt: state.lastProgressAdvanceAt,
@@ -1061,13 +1094,6 @@ export async function rotateStreamerIfInvalid(
     });
     state.invalidStreamChecks = INVALID_STREAM_THRESHOLD;
   } else {
-    const progressIsLive =
-      state.lastProgressAdvanceAt > 0 && now - state.lastProgressAdvanceAt < PROGRESS_STALL_THRESHOLD_MS;
-    const isWeakSignal = health.reason === 'drops-inactive' || health.reason === 'missing-context';
-    if (progressIsLive && isWeakSignal) {
-      state.invalidStreamChecks = 0;
-      return;
-    }
     state.invalidStreamChecks += health.invalidIncrement;
   }
   if (state.invalidStreamChecks < INVALID_STREAM_THRESHOLD) {
@@ -1116,11 +1142,6 @@ export async function checkDropProgress(
     return;
   }
 
-  if (state.apiBackoffUntil > 0 && Date.now() < state.apiBackoffUntil) {
-    logDebug('API backoff active, skipping tick', { remainingMs: state.apiBackoffUntil - Date.now() });
-    return;
-  }
-
   state.lastHeartbeatAt = Date.now();
 
   logDebug('Tick entry', {
@@ -1146,6 +1167,13 @@ export async function checkDropProgress(
   }, TICK_WATCHDOG_TIMEOUT_MS);
 
   try {
+    if (state.apiBackoffUntil > 0 && Date.now() < state.apiBackoffUntil) {
+      logDebug('API backoff active, skipping network refresh work', {
+        remainingMs: state.apiBackoffUntil - Date.now(),
+      });
+      return;
+    }
+
     const noStreamersRecoveryActive =
       state.appState.recoveryReason === 'no-streamers' && state.recoveryBackoffUntil > 0;
     if (noStreamersRecoveryActive) {

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -736,6 +736,7 @@ async function fetchInventorySnapshotFromApi(
       onEnsureTwitchSession: ensureTwitchSession,
       onIsLikelyAuthError: isLikelyAuthError,
       onClearTwitchSessionCache: clearTwitchSessionCacheExt,
+      onStopFarmingSession: stopFarmingSession,
     },
     { logWarn },
   );
@@ -997,6 +998,7 @@ async function skipCurrentGameDueToNoStreamers() {
     onSaveState: () => saveStateExt(state),
     onSaveTimingState: saveTimingStateExt,
     onStopFarmingSession: stopFarmingSession,
+    onNotify: notify,
   });
 }
 
@@ -1080,6 +1082,7 @@ async function skipCurrentGameDueToOfflineRecovery() {
     onSaveState: () => saveStateExt(state),
     onSaveTimingState: saveTimingStateExt,
     onStopFarmingSession: stopFarmingSession,
+    onNotify: notify,
   });
 }
 
@@ -1092,7 +1095,11 @@ async function rotateStreamerIfInvalid() {
     onSaveTimingState: saveTimingStateExt,
     onRotateStreamer: rotateStreamerExt,
     onOpenStreamer: acquireStreamerForSelectedGame,
-    onEnterPersistentRecovery: enterPersistentRecoveryExt,
+    onEnterPersistentRecovery: async (nextState, reason, message, recoveryOpts) =>
+      enterPersistentRecoveryExt(nextState, reason, message, {
+        ...recoveryOpts,
+        onNotify: notify,
+      }),
     onSkipCurrentGame: skipCurrentGameDueToOfflineRecovery,
   });
 }
@@ -1344,6 +1351,19 @@ function getChannelNameFromTab(url: string | undefined): string | null {
   return getFarmableTwitchChannelNameFromUrl(url);
 }
 
+function isTrustedTwitchSender(sender: chrome.runtime.MessageSender): boolean {
+  const url = sender.tab?.url ?? sender.url ?? '';
+  if (getFarmableTwitchChannelNameFromUrl(url) !== null) {
+    return true;
+  }
+  try {
+    const parsed = new URL(url);
+    return /(^|\.)twitch\.tv$/i.test(parsed.hostname) && /^\/drops\/campaigns(?:\/|$)/i.test(parsed.pathname);
+  } catch {
+    return false;
+  }
+}
+
 async function recordChannelPointsBonusClaimed(channelName?: string | null) {
   await ensureInitializedForStatsUpdate();
   appState.totalChannelPointsClaimed = appState.totalChannelPointsClaimed + 1;
@@ -1373,6 +1393,9 @@ function sessionPayloadCandidate(payload: unknown): unknown {
 }
 
 async function handleSyncTwitchSession(payload: unknown, sender: chrome.runtime.MessageSender) {
+  if (!isTrustedTwitchSender(sender)) {
+    return { success: false, error: 'Untrusted message sender' };
+  }
   const incoming = sanitizeTwitchSession(sessionPayloadCandidate(payload));
   if (!incoming) {
     return { success: false, error: 'Invalid session payload' };
@@ -1389,11 +1412,17 @@ async function handleSyncTwitchSession(payload: unknown, sender: chrome.runtime.
   return { success: true };
 }
 
-async function handleSyncTwitchIntegrity(payload?: {
-  token?: string;
-  expiration?: number;
-  request_id?: string;
-}) {
+async function handleSyncTwitchIntegrity(
+  payload?: {
+    token?: string;
+    expiration?: number;
+    request_id?: string;
+  },
+  sender?: chrome.runtime.MessageSender,
+) {
+  if (!sender || !isTrustedTwitchSender(sender)) {
+    return { success: false, error: 'Untrusted message sender' };
+  }
   const token = typeof payload?.token === 'string' ? payload.token.trim() : '';
   if (!token) {
     return { success: false, error: 'Empty integrity token' };
@@ -1423,6 +1452,9 @@ async function handleChannelPointsBonusClaimed(
   payload: { channelName?: string | null } | undefined,
   sender: chrome.runtime.MessageSender,
 ) {
+  if (!isTrustedTwitchSender(sender)) {
+    return { success: false, error: 'Untrusted message sender' };
+  }
   logDebug('Channel points bonus claimed by content script', { tabId: sender.tab?.id });
   await recordChannelPointsBonusClaimed(payload?.channelName ?? getChannelNameFromTab(sender.tab?.url));
   return { success: true };
@@ -1442,7 +1474,7 @@ registerRuntimeMessageRouter({
   stopFarming: () => handleStopFarming(),
   updateGames: (message) => handleUpdateGames(message.payload),
   syncTwitchSession: (message, sender) => handleSyncTwitchSession(message.payload, sender),
-  syncTwitchIntegrity: (message) => handleSyncTwitchIntegrity(message.payload),
+  syncTwitchIntegrity: (message, sender) => handleSyncTwitchIntegrity(message.payload, sender),
   refreshDrops: () => handleRefreshDrops(),
   setMonitorAutoOpen: (message) => handleSetMonitorAutoOpen(message.payload),
   setMuteFarmingTab: (message) => handleSetMuteFarmingTab(message.payload),

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -823,6 +823,9 @@ async function refreshGamesCacheFromHiddenFetch(
 }
 
 async function openDropsPageAndRefresh(message?: { payload?: { waitForRefresh?: boolean } }) {
+  if (initPromise) {
+    await initPromise;
+  }
   return dropsPageRefresher.openDropsPageAndRefresh({
     waitForRefresh: message?.payload?.waitForRefresh,
   });
@@ -1162,6 +1165,9 @@ async function handleClearQueue() {
 }
 
 async function handleEnsureGamesCache(payload?: { force?: boolean }) {
+  if (initPromise) {
+    await initPromise;
+  }
   await trackActivity('ensure-games-cache');
   await ensureStateHydratedForCache();
   const force = Boolean(payload?.force);
@@ -1395,6 +1401,9 @@ function sessionPayloadCandidate(payload: unknown): unknown {
 async function handleSyncTwitchSession(payload: unknown, sender: chrome.runtime.MessageSender) {
   if (!isTrustedTwitchSender(sender)) {
     return { success: false, error: 'Untrusted message sender' };
+  }
+  if (initPromise) {
+    await initPromise;
   }
   const incoming = sanitizeTwitchSession(sessionPayloadCandidate(payload));
   if (!incoming) {

--- a/src/background/state-persistence.ts
+++ b/src/background/state-persistence.ts
@@ -257,7 +257,10 @@ export async function resetStateForInactivity(
       [deps.LAST_ACTIVITY_AT_KEY]: state.lastActivityAt,
     })
     .catch(() => undefined);
-  await chrome.storage.session.remove([deps.TIMING_STATE_KEY]).catch(() => undefined);
+  await Promise.all([
+    chrome.storage.local.remove(deps.TIMING_STATE_KEY).catch(() => undefined),
+    chrome.storage.session.remove(deps.TIMING_STATE_KEY).catch(() => undefined),
+  ]);
   await callbacks.onSaveTimingState(state);
   callbacks.onBroadcastStateUpdate(state.appState);
 }

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -521,12 +521,13 @@ function App() {
   const openDropsPage = () =>
     withAction(async () => {
       setQueueMessage('Opening Twitch Drops...');
+      setState((prev) => ({ ...prev, dropsPageRefreshInProgress: true }));
       const response = await sendRuntimeMessage({
         type: 'OPEN_DROPS_PAGE_AND_REFRESH',
         payload: { waitForRefresh: false },
       }).catch((error: unknown) => ({ success: false as const, error: String(error) }));
-      setState(await loadStoredAppState());
       if (response && response.success === false) {
+        setState(await loadStoredAppState());
         setQueueMessage(response.error ?? 'Opened Twitch. Waiting for DropHunter to detect your session.');
         return;
       }

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -136,12 +136,152 @@ export type RuntimeResponseByType = {
 
 const runtimeMessageTypeSet = new Set<string>(RUNTIME_MESSAGE_TYPES);
 
+export function isRuntimeMessageType(value: unknown): value is RuntimeMessageType {
+  return typeof value === 'string' && runtimeMessageTypeSet.has(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isOptionalBooleanPayload(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (isRecord(value) && (value.enabled === undefined || typeof value.enabled === 'boolean'))
+  );
+}
+
+function isTwitchGameLike(value: unknown): value is TwitchGame {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    value.id.trim().length > 0 &&
+    typeof value.name === 'string' &&
+    value.name.trim().length > 0 &&
+    typeof value.imageUrl === 'string'
+  );
+}
+
+function hasGamePayload(value: unknown, allowMissingGame = false): boolean {
+  if (!isRecord(value)) {
+    return allowMissingGame && value === undefined;
+  }
+  return value.game === undefined ? allowMissingGame : isTwitchGameLike(value.game);
+}
+
+function isRuntimePayloadValid(type: RuntimeMessageType, payload: unknown): boolean {
+  switch (type) {
+    case 'START_FARMING':
+      return hasGamePayload(payload, true);
+    case 'ADD_TO_QUEUE':
+      return hasGamePayload(payload, false);
+    case 'SET_SELECTED_GAME':
+      return isRecord(payload) && isTwitchGameLike(payload.game);
+    case 'UPDATE_GAMES':
+      return payload === undefined || (Array.isArray(payload) && payload.every(isTwitchGameLike));
+    case 'SYNC_TWITCH_SESSION':
+      return isRecord(payload);
+    case 'SYNC_TWITCH_INTEGRITY':
+      return (
+        isRecord(payload) &&
+        typeof payload.token === 'string' &&
+        payload.token.trim().length > 0 &&
+        (payload.expiration === undefined || typeof payload.expiration === 'number') &&
+        (payload.request_id === undefined || typeof payload.request_id === 'string')
+      );
+    case 'CHANNEL_POINTS_BONUS_CLAIMED':
+      return (
+        payload === undefined ||
+        (isRecord(payload) &&
+          (payload.channelName === undefined ||
+            payload.channelName === null ||
+            typeof payload.channelName === 'string'))
+      );
+    case 'REMOVE_FROM_QUEUE':
+      return (
+        isRecord(payload) &&
+        (payload.game === undefined || isTwitchGameLike(payload.game)) &&
+        (payload.gameId === undefined || typeof payload.gameId === 'string') &&
+        (payload.campaignId === undefined || typeof payload.campaignId === 'string')
+      );
+    case 'OPEN_DROPS_PAGE_AND_REFRESH':
+      return (
+        payload === undefined ||
+        (isRecord(payload) &&
+          (payload.waitForRefresh === undefined || typeof payload.waitForRefresh === 'boolean'))
+      );
+    case 'ENSURE_GAMES_CACHE':
+      return (
+        payload === undefined ||
+        (isRecord(payload) && (payload.force === undefined || typeof payload.force === 'boolean'))
+      );
+    case 'OPEN_MONITOR_DASHBOARD':
+      return (
+        payload === undefined ||
+        (isRecord(payload) && (payload.toggle === undefined || typeof payload.toggle === 'boolean'))
+      );
+    case 'SET_MONITOR_AUTO_OPEN':
+    case 'SET_AUTO_RESUME_ON_STARTUP':
+    case 'SET_MUTE_FARMING_TAB':
+    case 'SET_NOTIFICATIONS_ENABLED':
+    case 'SET_AUTO_CLAIM_CHANNEL_POINTS_BONUS':
+    case 'SET_AUTO_CLAIM_DROPS':
+      return isOptionalBooleanPayload(payload);
+    case 'SET_STREAMER_SELECTION_MODE':
+      return (
+        payload === undefined ||
+        (isRecord(payload) &&
+          (payload.mode === undefined ||
+            payload.mode === 'low-view' ||
+            payload.mode === 'random' ||
+            payload.mode === 'top-viewers'))
+      );
+    case 'SET_PREFERRED_STREAMER_LANGUAGE':
+      return (
+        payload === undefined ||
+        (isRecord(payload) &&
+          (payload.language === undefined ||
+            payload.language === null ||
+            typeof payload.language === 'string'))
+      );
+    case 'PLAY_ALERT':
+      return (
+        payload === undefined ||
+        (isRecord(payload) &&
+          (payload.kind === undefined ||
+            payload.kind === 'all-complete' ||
+            payload.kind === 'drop-complete') &&
+          (payload.message === undefined || typeof payload.message === 'string'))
+      );
+    case 'OPEN_STREAMER':
+      return (
+        payload === undefined ||
+        (isRecord(payload) &&
+          (payload.game === undefined || isTwitchGameLike(payload.game)) &&
+          (payload.streamer === undefined || isRecord(payload.streamer)))
+      );
+    case 'GET_TWITCH_SESSION':
+    case 'GET_STREAM_CONTEXT':
+    case 'PREPARE_STREAM_PLAYBACK':
+    case 'CLAIM_CHANNEL_POINTS_BONUS':
+    case 'CLEAR_QUEUE':
+    case 'PAUSE_FARMING':
+    case 'RESUME_FARMING':
+    case 'STOP_FARMING':
+    case 'REFRESH_DROPS':
+    case 'UPDATE_STATE':
+      return true;
+    default:
+      return true;
+  }
+}
+
 export function isRuntimeRequest(value: unknown): value is RuntimeRequest {
   if (!value || typeof value !== 'object' || !('type' in value)) {
     return false;
   }
   const type = (value as { type?: unknown }).type;
-  return typeof type === 'string' && runtimeMessageTypeSet.has(type);
+  return isRuntimeMessageType(type) && isRuntimePayloadValid(type, (value as { payload?: unknown }).payload);
 }
 
 export async function sendRuntimeMessage<T extends RuntimeRequest['type']>(

--- a/tests/api-operations.test.ts
+++ b/tests/api-operations.test.ts
@@ -303,6 +303,21 @@ describe('fetchDropsSnapshotFromApi', () => {
     expect(state.apiBackoffUntil).toBeLessThanOrEqual(after + 60 * 1000);
   });
 
+  test('rethrows auth errors so wrappers can refresh the Twitch session', async () => {
+    const { fetchDropsSnapshotFromApi } = await import('../src/background/api-operations.ts');
+
+    const state = createMinimalState({ apiConsecutiveFailures: 0 });
+    const session = createSession();
+
+    originalFetch = installFetchMock([
+      async () => { throw new Error('401 unauthorized'); },
+    ]);
+
+    await expect(fetchDropsSnapshotFromApi(state, session)).rejects.toThrow('401 unauthorized');
+    expect(state.apiConsecutiveFailures).toBe(0);
+    expect(state.apiBackoffUntil).toBe(0);
+  });
+
   test('backoff is capped at 10 minutes with high failure count', async () => {
     const { fetchDropsSnapshotFromApi } = await import('../src/background/api-operations.ts');
 
@@ -430,6 +445,69 @@ describe('fetchDropsSnapshotFromApi', () => {
     expect(result).toBeNull();
     expect(state.apiConsecutiveFailures).toBeGreaterThan(0);
   });
+
+  test('wrapper stops running farming when auth still fails after forced session refresh', async () => {
+    const { fetchDropsSnapshotFromApiWrapper } = await import('../src/background/api-operations.ts');
+    const { TwitchApiClient } = await import('../src/background/twitch-api/client.ts');
+
+    const session = createSession();
+    const state = createMinimalState({
+      appState: { ...createInitialState(), isRunning: true },
+      twitchSessionCache: session,
+    });
+    const ensureCalls: boolean[] = [];
+    let stopReason: string | undefined;
+
+    let dashboardCalls = 0;
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
+      if (body?.operationName === 'ViewerDropsDashboard') {
+        dashboardCalls += 1;
+        throw new Error(dashboardCalls === 1 ? '401 unauthorized' : 'invalid oauth token');
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => buildInventoryResponse(),
+        text: async () => JSON.stringify(buildInventoryResponse()),
+      } as Response;
+    }) as FetchMock;
+
+    const result = await fetchDropsSnapshotFromApiWrapper(
+      state,
+      false,
+      {
+        onEnsureTwitchSession: async (forceRefresh = false) => {
+          ensureCalls.push(forceRefresh);
+          return session;
+        },
+        onEnsureSessionIntegrity: async () => session,
+        onPersistTwitchSession: async () => undefined,
+        onStopFarmingSession: async (options) => {
+          stopReason = options.stopReason;
+        },
+        onIsLikelyAuthError: (error) => /401|invalid oauth token/i.test(String(error)),
+        onClearTwitchSessionCache: (nextState) => {
+          nextState.twitchSessionCache = null;
+        },
+      },
+      {
+        TwitchApiClient,
+        sessionDebugSummary: (nextSession) => ({ available: Boolean(nextSession) }),
+        PROGRESS_POLL_MS: 60_000,
+        logDebug: () => undefined,
+        logWarn: () => undefined,
+        logInfo: () => undefined,
+      },
+    );
+
+    expect(result).toBeNull();
+    expect(ensureCalls).toEqual([false, true]);
+    expect(stopReason).toBe('sign-in-required');
+    expect(state.apiConsecutiveFailures).toBe(0);
+    expect(state.apiBackoffUntil).toBe(0);
+  });
 });
 
 describe('fetchInventorySnapshotFromApi', () => {
@@ -492,6 +570,92 @@ describe('fetchInventorySnapshotFromApi', () => {
     expect(result?.drops[0].remainingMinutes).toBe(60);
     expect(result?.drops[0].progressSource).toBe('inventory');
     expect(state.apiConsecutiveFailures).toBe(0);
+  });
+
+  test('rethrows inventory auth errors so wrappers can refresh the Twitch session', async () => {
+    const { fetchInventorySnapshotFromApi } = await import('../src/background/api-operations.ts');
+
+    const state = createMinimalState();
+    const session = createSession();
+    const cachedDrops: TwitchDrop[] = [
+      {
+        id: 'drop-1',
+        name: 'For Honor Drop',
+        gameId: 'campaign-for-honor',
+        gameName: 'For Honor',
+        imageUrl: 'https://example.com/drop.png',
+        progress: 50,
+        currentMinutes: 120,
+        claimed: false,
+        campaignId: 'campaign-for-honor',
+        requiredMinutes: 240,
+      },
+    ];
+
+    originalFetch = installFetchMock([
+      async () => { throw new Error('403 forbidden'); },
+    ]);
+
+    await expect(fetchInventorySnapshotFromApi(state, session, cachedDrops)).rejects.toThrow(
+      '403 forbidden',
+    );
+    expect(state.apiConsecutiveFailures).toBe(0);
+    expect(state.apiBackoffUntil).toBe(0);
+  });
+
+  test('wrapper stops running farming when inventory auth still fails after forced session refresh', async () => {
+    const { fetchInventorySnapshotFromApiWrapper } = await import('../src/background/api-operations.ts');
+
+    const session = createSession();
+    const state = createMinimalState({
+      appState: { ...createInitialState(), isRunning: true },
+      twitchSessionCache: session,
+    });
+    const ensureCalls: boolean[] = [];
+    let stopReason: string | undefined;
+    const cachedDrops: TwitchDrop[] = [
+      {
+        id: 'drop-1',
+        name: 'For Honor Drop',
+        gameId: 'campaign-for-honor',
+        gameName: 'For Honor',
+        imageUrl: 'https://example.com/drop.png',
+        progress: 50,
+        currentMinutes: 120,
+        claimed: false,
+        campaignId: 'campaign-for-honor',
+        requiredMinutes: 240,
+      },
+    ];
+
+    originalFetch = installFetchMock([
+      async () => { throw new Error('403 forbidden'); },
+      async () => { throw new Error('invalid oauth token'); },
+    ]);
+
+    const result = await fetchInventorySnapshotFromApiWrapper(
+      state,
+      cachedDrops,
+      false,
+      {
+        onEnsureTwitchSession: async (forceRefresh = false) => {
+          ensureCalls.push(forceRefresh);
+          return session;
+        },
+        onStopFarmingSession: async (options) => {
+          stopReason = options.stopReason;
+        },
+        onIsLikelyAuthError: (error) => /403|invalid oauth token/i.test(String(error)),
+        onClearTwitchSessionCache: (nextState) => {
+          nextState.twitchSessionCache = null;
+        },
+      },
+      { logWarn: () => undefined },
+    );
+
+    expect(result).toBeNull();
+    expect(ensureCalls).toEqual([false, true]);
+    expect(stopReason).toBe('sign-in-required');
   });
 });
 

--- a/tests/auto-claim-cross-game.test.ts
+++ b/tests/auto-claim-cross-game.test.ts
@@ -460,14 +460,14 @@ async function waitForCondition(check: () => boolean, message: string) {
   throw new Error(message);
 }
 
-async function dispatchMessage(message: Message): Promise<unknown> {
+async function dispatchMessage(message: Message, sender: chrome.runtime.MessageSender = {}): Promise<unknown> {
   const handler = chromeMocks.runtime.onMessage._handlers[0];
   if (!handler) {
     throw new Error('service worker onMessage handler not registered');
   }
 
   return new Promise((resolve) => {
-    handler(message, {}, (response?: unknown) => resolve(response));
+    handler(message, sender, (response?: unknown) => resolve(response));
   });
 }
 
@@ -487,6 +487,11 @@ async function syncTestSession() {
         deviceId: 'device-12345678',
         uuid: 'uuid-1',
       },
+    },
+  }, {
+    tab: {
+      id: 999,
+      url: 'https://www.twitch.tv/drops/campaigns',
     },
   });
 }

--- a/tests/drops-page-refresh.test.ts
+++ b/tests/drops-page-refresh.test.ts
@@ -123,4 +123,37 @@ describe('drops page refresher', () => {
       'broadcast',
     ]);
   });
+
+  test('clears background refresh progress when the async refresh fails', async () => {
+    const state = { appState: createInitialState() };
+    const tabsApi = createTabsApi();
+    let finishTabLoad: () => void = () => {};
+    const tabLoadStarted = new Promise<void>((resolve) => {
+      finishTabLoad = resolve;
+    });
+    const refresher = createDropsPageRefresher(state, {
+      tabsApi,
+      trackActivity: async () => {},
+      ensureStateHydratedForCache: async () => {},
+      waitForTabComplete: async () => {
+        await tabLoadStarted;
+      },
+      persistSessionFromDropsPage: async () => {
+        throw new Error('session unavailable');
+      },
+      refreshGamesCacheFromHiddenFetch: async () => {},
+      saveState: async () => {},
+      broadcastStateUpdate: () => {},
+    });
+
+    const result = await refresher.openDropsPageAndRefresh({ waitForRefresh: false });
+
+    expect(result.refreshed).toBe(false);
+    expect(state.appState.dropsPageRefreshInProgress).toBe(true);
+
+    finishTabLoad();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(state.appState.dropsPageRefreshInProgress).toBe(false);
+  });
 });

--- a/tests/message-router.test.ts
+++ b/tests/message-router.test.ts
@@ -62,6 +62,34 @@ describe('runtime message router', () => {
     expect(result.response).toEqual({ success: false, error: 'Unknown message type' });
   });
 
+  test('rejects critical messages with malformed payloads before invoking handlers', async () => {
+    let startCalled = false;
+    let syncCalled = false;
+    const listener = createRuntimeMessageListener(
+      createHandlers({
+        startFarming: async () => {
+          startCalled = true;
+          return { success: true };
+        },
+        syncTwitchIntegrity: async () => {
+          syncCalled = true;
+          return { success: true };
+        },
+      }),
+    );
+
+    const start = await callListener(listener, { type: 'START_FARMING', payload: { game: null } });
+    const integrity = await callListener(listener, {
+      type: 'SYNC_TWITCH_INTEGRITY',
+      payload: { token: 123 },
+    });
+
+    expect(start.response).toEqual({ success: false, error: 'Invalid message payload' });
+    expect(integrity.response).toEqual({ success: false, error: 'Invalid message payload' });
+    expect(startCalled).toBe(false);
+    expect(syncCalled).toBe(false);
+  });
+
   test('rejects messages that are not handled by the background service worker', async () => {
     const listener = createRuntimeMessageListener(createHandlers());
 

--- a/tests/mocks/chrome.ts
+++ b/tests/mocks/chrome.ts
@@ -79,8 +79,10 @@ function createStorageMock() {
       for (const [k, v] of Object.entries(items)) store.set(k, v);
       return Promise.resolve();
     },
-    remove(key: string): Promise<void> {
-      store.delete(key);
+    remove(key: string | string[]): Promise<void> {
+      for (const entry of Array.isArray(key) ? key : [key]) {
+        store.delete(entry);
+      }
       return Promise.resolve();
     },
     clear(): Promise<void> {

--- a/tests/queue-management.test.ts
+++ b/tests/queue-management.test.ts
@@ -383,10 +383,24 @@ describe('enterPersistentRecovery', () => {
 
   test('sends notification only on first recovery entry', async () => {
     const state = createMinimalState({ recoveryNotificationSent: false });
-    await enterPersistentRecovery(state, 'stalled-progress', 'Test message');
+    const notifications: Array<{ title: string; message: string; priority?: number }> = [];
+    await enterPersistentRecovery(state, 'stalled-progress', 'Test message', {
+      onNotify: async (title, message, priority) => {
+        notifications.push({ title, message, priority });
+      },
+    });
     expect(state.recoveryNotificationSent).toBe(true);
 
-    await enterPersistentRecovery(state, 'stalled-progress', 'Test message');
+    await enterPersistentRecovery(state, 'stalled-progress', 'Test message', {
+      onNotify: async (title, message, priority) => {
+        notifications.push({ title, message, priority });
+      },
+    });
+
+    expect(notifications).toEqual([
+      { title: 'DropHunter is still recovering', message: 'Test message', priority: 1 },
+    ]);
+    expect(mocks.notifications._notifications).toEqual([]);
   });
 });
 
@@ -503,16 +517,21 @@ describe('skipCurrentGameAndAdvanceQueue', () => {
     state.appState.queue = [current, next];
 
     try {
+      const notifications: Array<{ title: string; message: string }> = [];
       await skipCurrentGameAndAdvanceQueue(state, 'no-streamers', {
         onSaveTimingState: async () => {},
         onOpenStreamer: async () => true,
+        onNotify: async (title, message) => {
+          notifications.push({ title, message });
+        },
       });
 
-      const notification = mocks.notifications._notifications[0] as { title?: string; message?: string } | undefined;
+      const notification = notifications[0];
       expect(notification?.title).toBe('Game skipped: no live streamers');
       expect(notification?.message).toContain('Skipped No Live Game');
       expect(notification?.message).toContain('no live streamers were found');
       expect(notification?.message).not.toContain('drop progress');
+      expect(mocks.notifications._notifications).toEqual([]);
     } finally {
       mocks.teardown();
     }
@@ -527,16 +546,21 @@ describe('skipCurrentGameAndAdvanceQueue', () => {
     state.appState.queue = [current, next];
 
     try {
+      const notifications: Array<{ title: string; message: string }> = [];
       await skipCurrentGameAndAdvanceQueue(state, 'stalled-progress', {
         onSaveTimingState: async () => {},
         onOpenStreamer: async () => true,
+        onNotify: async (title, message) => {
+          notifications.push({ title, message });
+        },
       });
 
-      const notification = mocks.notifications._notifications[0] as { title?: string; message?: string } | undefined;
+      const notification = notifications[0];
       expect(notification?.title).toBe('Game skipped: no drop progress');
       expect(notification?.message).toContain('Skipped Stalled Game');
       expect(notification?.message).toContain('stream opened but drop progress did not resume');
       expect(notification?.message).not.toContain('no live streamers');
+      expect(mocks.notifications._notifications).toEqual([]);
     } finally {
       mocks.teardown();
     }
@@ -1615,6 +1639,37 @@ describe('checkDropProgress', () => {
     expect(calls).toEqual(['playback-policy', 'refresh-drops', 'validate-stream']);
     expect(attemptSelfHealCalled).toBe(false);
     expect(rotateReason).toBeNull();
+  });
+
+  test('persists heartbeat timing when API backoff skips network refresh work', async () => {
+    const state = createMinimalState({
+      apiBackoffUntil: Date.now() + 60_000,
+      lastHeartbeatAt: 0,
+    });
+    state.appState.isRunning = true;
+    state.appState.selectedGame = createGame();
+
+    let refreshCalled = false;
+    let savedHeartbeat = 0;
+    await checkDropProgress(state, {
+      onEnforcePlaybackPolicy: async () => undefined,
+      onAcquireStreamerForSelectedGame: async () => false,
+      onRefreshDropsData: async () => {
+        refreshCalled = true;
+      },
+      onRotateStreamerIfInvalid: async () => undefined,
+      onAttemptAutoClaimChannelPointsBonus: async () => false,
+      onAutoClaimClaimableDrops: async () => false,
+      onAdvanceQueueIfCompleted: async () => true,
+      onSaveTimingState: async (nextState) => {
+        savedHeartbeat = nextState.lastHeartbeatAt;
+      },
+    });
+
+    expect(refreshCalled).toBe(false);
+    expect(state.lastHeartbeatAt).toBeGreaterThan(0);
+    expect(savedHeartbeat).toBe(state.lastHeartbeatAt);
+    expect(state.monitorTickInFlight).toBe(false);
   });
 
   test('requests a full campaign refresh when the full tick interval elapses', async () => {

--- a/tests/service-worker.test.ts
+++ b/tests/service-worker.test.ts
@@ -428,17 +428,20 @@ async function resetWorkerState() {
 }
 
 async function syncTestSession() {
-  await dispatchMessage({
-    type: 'SYNC_TWITCH_SESSION',
-    payload: {
-      session: {
-        oauthToken: 'oauth-token-with-valid-length-1234567890',
-        userId: '123456',
-        deviceId: 'device-12345678',
-        uuid: 'uuid-1',
+  await dispatchMessage(
+    {
+      type: 'SYNC_TWITCH_SESSION',
+      payload: {
+        session: {
+          oauthToken: 'oauth-token-with-valid-length-1234567890',
+          userId: '123456',
+          deviceId: 'device-12345678',
+          uuid: 'uuid-1',
+        },
       },
     },
-  });
+    { tab: { id: 42, url: 'https://www.twitch.tv/drops/campaigns' } },
+  );
 }
 
 async function addGameToQueue(game: TwitchGame) {
@@ -503,7 +506,7 @@ describe('service worker message handlers', () => {
 
     const response = await dispatchMessage(
       { type: 'CHANNEL_POINTS_BONUS_CLAIMED', payload: { channelName: 'trevonerd' } },
-      { tab: { id: 123 } },
+      { tab: { id: 123, url: 'https://www.twitch.tv/trevonerd' } },
     );
 
     expect(response).toEqual({ success: true });
@@ -695,6 +698,38 @@ describe('service worker message handlers', () => {
     expect(getAppStateFromStorage().availableGames).toHaveLength(1);
   });
 
+  test('rejects sensitive content-script sync from non-Twitch senders', async () => {
+    const before = getAppStateFromStorage().totalChannelPointsClaimed;
+
+    const sessionResponse = await dispatchMessage(
+      {
+        type: 'SYNC_TWITCH_SESSION',
+        payload: {
+          session: {
+            oauthToken: 'oauth-token-with-valid-length-1234567890',
+            userId: '123456',
+            deviceId: 'device-12345678',
+            uuid: 'uuid-1',
+          },
+        },
+      },
+      { tab: { id: 666, url: 'https://example.com/not-twitch' } },
+    );
+    const integrityResponse = await dispatchMessage(
+      { type: 'SYNC_TWITCH_INTEGRITY', payload: { token: 'integrity-token', expiration: 0 } },
+      { tab: { id: 666, url: 'https://example.com/not-twitch' } },
+    );
+    const channelPointsResponse = await dispatchMessage(
+      { type: 'CHANNEL_POINTS_BONUS_CLAIMED', payload: { channelName: 'bad-sender' } },
+      { tab: { id: 666, url: 'https://example.com/not-twitch' } },
+    );
+
+    expect(sessionResponse).toEqual({ success: false, error: 'Untrusted message sender' });
+    expect(integrityResponse).toEqual({ success: false, error: 'Untrusted message sender' });
+    expect(channelPointsResponse).toEqual({ success: false, error: 'Untrusted message sender' });
+    expect(getAppStateFromStorage().totalChannelPointsClaimed).toBe(before);
+  });
+
   test('PAUSE_FARMING sets isPaused via chrome.runtime.onMessage.trigger', async () => {
     chromeMocks.runtime.onMessage.trigger({ type: 'PAUSE_FARMING' });
 
@@ -747,7 +782,7 @@ describe('service worker message handlers', () => {
 
     const response = await dispatchMessage(
       { type: 'CHANNEL_POINTS_BONUS_CLAIMED', payload: { channelName: 'quiet-channel' } },
-      { tab: { id: 123 } },
+      { tab: { id: 123, url: 'https://www.twitch.tv/quiet-channel' } },
     );
 
     expect(response).toEqual({ success: true });
@@ -796,7 +831,7 @@ describe('service worker message handlers', () => {
     chromeMocks.permissions.setContainsResult(false);
     const response = await dispatchMessage(
       { type: 'CHANNEL_POINTS_BONUS_CLAIMED', payload: { channelName: 'missing-permission' } },
-      { tab: { id: 123 } },
+      { tab: { id: 123, url: 'https://www.twitch.tv/missing-permission' } },
     );
 
     expect(response).toEqual({ success: true });

--- a/tests/service-worker.test.ts
+++ b/tests/service-worker.test.ts
@@ -3,6 +3,7 @@ import { setupChromeMocks, type ChromeMocks } from './mocks/chrome';
 import type { RuntimeRequest } from '../src/shared/messages.ts';
 import type { AppState, TwitchGame } from '../src/types/index.ts';
 import { setTimingSaveDebounceMsForTests } from '../src/background/state-persistence.ts';
+import { createInitialState } from '../src/shared/utils.ts';
 
 const chromeMocks = setupChromeMocks();
 setTimingSaveDebounceMsForTests(0);
@@ -111,10 +112,10 @@ function installServiceWorkerSupportMocks(mocks: ChromeMocks) {
   chromeAny.storage.sync = syncStorage;
   chromeAny.storage.local.remove = async (keys: string | string[]) => {
     if (Array.isArray(keys)) {
-      keys.forEach((key) => chromeMocks.storage.local._store.delete(key));
+      keys.forEach((key) => mocks.storage.local._store.delete(key));
       return;
     }
-    chromeMocks.storage.local._store.delete(keys);
+    mocks.storage.local._store.delete(keys);
   };
 
   mocks.tabs.setTabsQueryResult([]);
@@ -420,6 +421,61 @@ async function dispatchMessage(message: RuntimeRequest, sender: Record<string, u
   });
 }
 
+async function dispatchMessageFromMocks(
+  mocks: ChromeMocks,
+  message: RuntimeRequest,
+  sender: Record<string, unknown> = {},
+): Promise<unknown> {
+  const handler = mocks.runtime.onMessage._handlers[0];
+  if (!handler) {
+    throw new Error('service worker onMessage handler not registered');
+  }
+
+  return new Promise((resolve) => {
+    handler(message, sender, (response?: unknown) => resolve(response));
+  });
+}
+
+async function importServiceWorkerWithBlockedInitialLoad(testId: string, appState: AppState) {
+  const isolatedMocks = setupChromeMocks();
+  installServiceWorkerSupportMocks(isolatedMocks);
+  await isolatedMocks.storage.local.set({ appState });
+
+  const chromeAny = (globalThis as unknown as { chrome: Record<string, any> }).chrome;
+  const originalGet = chromeAny.storage.local.get.bind(chromeAny.storage.local);
+  const originalSet = chromeAny.storage.local.set.bind(chromeAny.storage.local);
+  const setCalls: Array<Record<string, unknown>> = [];
+  let initialLoadBlocked = false;
+  let releaseInitialLoad: () => void = () => {};
+  const initialLoadStarted = new Promise<void>((resolveStarted) => {
+    const releasePromise = new Promise<void>((resolveRelease) => {
+      releaseInitialLoad = resolveRelease;
+    });
+    chromeAny.storage.local.get = async (keys: unknown) => {
+      if (!initialLoadBlocked && Array.isArray(keys) && keys.includes('appState')) {
+        initialLoadBlocked = true;
+        resolveStarted();
+        await releasePromise;
+      }
+      return originalGet(keys);
+    };
+  });
+
+  chromeAny.storage.local.set = async (items: Record<string, unknown>) => {
+    setCalls.push(items);
+    return originalSet(items);
+  };
+
+  await import(`../src/background/service-worker.ts?init-race-${testId}-${Date.now()}`);
+  await initialLoadStarted;
+
+  return {
+    mocks: isolatedMocks,
+    releaseInitialLoad,
+    setCalls,
+  };
+}
+
 async function resetWorkerState() {
   await dispatchMessage({ type: 'STOP_FARMING' });
   await dispatchMessage({ type: 'CLEAR_QUEUE' });
@@ -481,6 +537,75 @@ describe('service worker message handlers', () => {
 
   test('registers runtime onMessage listener at module load', () => {
     expect(chromeMocks.runtime.onMessage._handlers.length).toBeGreaterThan(0);
+  });
+
+  test('OPEN_DROPS_PAGE_AND_REFRESH waits for initialization before touching refresh state', async () => {
+    const isolated = await importServiceWorkerWithBlockedInitialLoad('open-drops', createInitialState());
+    try {
+      const chromeAny = (globalThis as unknown as { chrome: Record<string, any> }).chrome;
+      let createCalls = 0;
+      chromeAny.tabs.create = async () => {
+        createCalls += 1;
+        return null;
+      };
+
+      const responsePromise = dispatchMessageFromMocks(isolated.mocks, {
+        type: 'OPEN_DROPS_PAGE_AND_REFRESH',
+        payload: { waitForRefresh: false },
+      });
+
+      await sleepTick();
+      await sleepTick();
+
+      expect(createCalls).toBe(0);
+      expect(isolated.setCalls).toHaveLength(0);
+
+      isolated.releaseInitialLoad();
+      const response = (await responsePromise) as { success?: boolean; error?: string };
+
+      expect(createCalls).toBe(1);
+      expect(response).toEqual({
+        success: false,
+        opened: false,
+        refreshed: false,
+        gamesCount: 0,
+        error: 'Unable to open the Twitch Drops page.',
+      });
+    } finally {
+      isolated.mocks.teardown();
+    }
+  });
+
+  test('ENSURE_GAMES_CACHE waits for initialization before touching cache state', async () => {
+    const persisted = {
+      ...createInitialState(),
+      availableGames: [demoGame],
+    };
+    const isolated = await importServiceWorkerWithBlockedInitialLoad('ensure-cache', persisted);
+    try {
+      let fetchCalls = 0;
+      globalThis.fetch = (async () => {
+        fetchCalls += 1;
+        throw new Error('unexpected fetch before initialization');
+      }) as typeof fetch;
+
+      const responsePromise = dispatchMessageFromMocks(isolated.mocks, { type: 'ENSURE_GAMES_CACHE' });
+
+      await sleepTick();
+      await sleepTick();
+
+      expect(fetchCalls).toBe(0);
+      expect(isolated.setCalls).toHaveLength(0);
+
+      isolated.releaseInitialLoad();
+      const response = (await responsePromise) as { success?: boolean; gamesCount?: number };
+
+      expect(response.success).toBe(true);
+      expect(response.gamesCount).toBe(1);
+      expect(fetchCalls).toBe(0);
+    } finally {
+      isolated.mocks.teardown();
+    }
   });
 
   test('START_FARMING returns an error when no game is provided', async () => {

--- a/tests/state-persistence.test.ts
+++ b/tests/state-persistence.test.ts
@@ -510,4 +510,50 @@ describe('resetStateForInactivity', () => {
       totalChannelPointsClaimed: 34,
     });
   });
+
+  test('removes stale timingState from local storage during inactivity reset even before timing save flushes', async () => {
+    const staleTiming = {
+      lastProgressAdvanceAt: 123456,
+      recoveryBackoffUntil: Date.now() + 60_000,
+      stalledRecoveryAttempts: 3,
+      lastHeartbeatAt: 999999,
+    };
+    await chrome.storage.local.set({ timingState: staleTiming });
+    await chrome.storage.session.set({ timingState: staleTiming });
+
+    const state = createMinimalState({
+      appState: createAppState({ isRunning: true, activeStreamer: { id: 's1', name: 'streamer', displayName: 'Streamer', isLive: true }, tabId: 321 }),
+      lastProgressAdvanceAt: 123456,
+      recoveryBackoffUntil: staleTiming.recoveryBackoffUntil,
+      stalledRecoveryAttempts: 3,
+    });
+
+    await resetStateForInactivity(
+      state,
+      'test',
+      999,
+      {
+        onStopMonitoring: () => undefined,
+        onClearRotationMetadata: (appState) => appState,
+        onResetStreamTrackingState: () => {
+          state.lastProgressAdvanceAt = 0;
+          state.recoveryBackoffUntil = 0;
+          state.stalledRecoveryAttempts = 0;
+        },
+        onSaveTimingState: async () => undefined,
+        onBroadcastStateUpdate: () => undefined,
+      },
+      {
+        createInitialState,
+        DROPS_SNAPSHOT_CACHE_KEY: 'dropsSnapshotCache',
+        LAST_ACTIVITY_AT_KEY: 'lastActivityAt',
+        TIMING_STATE_KEY: 'timingState',
+      },
+    );
+
+    expect(mocks.storage.local._store.has('timingState')).toBe(false);
+    expect(mocks.storage.session._store.has('timingState')).toBe(false);
+    expect(state.appState.tabId).toBeNull();
+    expect(state.appState.activeStreamer).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- Keep the current streamer when drop progress is still advancing, while preserving real fatal rotation cases.
- Harden Twitch API auth recovery so persistent 401/403/invalid-token failures surface as `sign-in-required` instead of silent backoff.
- Route recovery notifications through the notification controller and validate sensitive runtime messages/senders.
- Make timing reset clear stale local `timingState` before saving fresh state.

## Why
The pre-release audit found hidden edge cases where DropHunter could rotate away from a working streamer, hide auth failures behind generic null/backoff paths, or restore stale timing after worker restart.

## Validation
- `bun run release:check`
- Push hook also ran `bun run test:ts`, `bun run lint`, `bun run test`, `bun run build`, and `bun audit` successfully.
