### PR TITLE
Fix Twitch emote/badge drops stuck at 98%

### DIFF
--- a/src/background/twitch-api/claimed-rewards.ts
+++ b/src/background/twitch-api/claimed-rewards.ts
@@ -1,3 +1,4 @@
+import type { TwitchDrop } from '../../types/index.ts';
 import { normalizeText, toIsoDate } from './parsing.ts';
 
 export type ClaimedRewardAwardedAt =
@@ -167,4 +168,84 @@ export function matchClaimedReward(
     entryHasAwardedBenefit(globalClaimedRewards, benefitIds, window, allowMissingGlobalAwardedAt);
 
   return { idMatch, nameMatch, globalIdMatch };
+}
+
+export function isEarlyAwardableTwitchReward(rewardDistributionTypes?: string[]): boolean {
+  return (rewardDistributionTypes ?? []).some((type) => type === 'BADGE' || type === 'EMOTE');
+}
+
+export function hasClaimedGameEventReward(
+  benefitIds: string[],
+  gameName: string,
+  claimedRewards: ClaimedRewardLookup,
+  globalClaimedRewards: ClaimedRewardEntry,
+  window: { startsAt: string | null; endsAt: string | null },
+): boolean {
+  const gameClaimedRewards = claimedRewards.get(gameName.toLowerCase());
+  const { idMatch, nameMatch, globalIdMatch } = matchClaimedReward(
+    benefitIds,
+    [],
+    gameClaimedRewards,
+    globalClaimedRewards,
+    window,
+    true,
+    true,
+  );
+  return idMatch || nameMatch || globalIdMatch;
+}
+
+export function resolveDropClaimedStatus(
+  claimedFromInventory: boolean,
+  claimedFromGameEvents: boolean,
+  hasInventoryState: boolean,
+  isEarlyAwardable: boolean,
+): boolean {
+  if (hasInventoryState) {
+    return claimedFromInventory || (isEarlyAwardable && claimedFromGameEvents);
+  }
+  return claimedFromInventory || claimedFromGameEvents;
+}
+
+export function applyEarlyTwitchRewardClaimsToDrops(
+  drops: TwitchDrop[],
+  inventoryRaw: unknown,
+): TwitchDrop[] {
+  if (!inventoryRaw || typeof inventoryRaw !== 'object') {
+    return drops;
+  }
+
+  const claimedRewards = buildClaimedRewardLookup(inventoryRaw);
+  const globalClaimedRewards = buildGlobalClaimedRewardEntry(inventoryRaw);
+
+  return drops.map((drop) => {
+    if (drop.claimed || !isEarlyAwardableTwitchReward(drop.rewardDistributionTypes)) {
+      return drop;
+    }
+
+    const benefitIds = drop.benefitIds ?? [];
+    if (benefitIds.length === 0) {
+      return drop;
+    }
+
+    const claimedFromGameEvents = hasClaimedGameEventReward(
+      benefitIds,
+      drop.gameName,
+      claimedRewards,
+      globalClaimedRewards,
+      { startsAt: drop.startsAt ?? null, endsAt: drop.endsAt ?? null },
+    );
+
+    if (!claimedFromGameEvents) {
+      return drop;
+    }
+
+    return {
+      ...drop,
+      claimed: true,
+      claimable: false,
+      progress: 100,
+      remainingMinutes: 0,
+      status: 'completed',
+    };
+  });
 }

--- a/src/background/twitch-api/client.ts
+++ b/src/background/twitch-api/client.ts
@@ -2,12 +2,15 @@ import { toSlug } from '../../shared/utils';
 import { DropStatus, DropsSnapshot, TwitchDrop, TwitchGame, TwitchStreamer } from '../../types';
 import { logDebug, logVerboseWarn, logWarn } from '../logging';
 import {
+  applyEarlyTwitchRewardClaimsToDrops,
   buildClaimedRewardLookup,
   buildGlobalClaimedIdCounts,
   buildGlobalClaimedRewardEntry,
   ClaimedRewardEntry,
   ClaimedRewardLookup,
+  isEarlyAwardableTwitchReward,
   matchClaimedReward,
+  resolveDropClaimedStatus,
 } from './claimed-rewards';
 import { TwitchGqlTransport } from './gql';
 import {
@@ -79,6 +82,7 @@ const CLAIM_DROP_REWARD_QUERY = {
 
 export type { ClaimedRewardEntry, ClaimedRewardLookup };
 export {
+  applyEarlyTwitchRewardClaimsToDrops,
   buildClaimedRewardLookup,
   buildGlobalClaimedIdCounts,
   buildGlobalClaimedRewardEntry,
@@ -86,9 +90,11 @@ export {
   extractBenefitDistributionTypes,
   extractBenefitIds,
   extractBenefitNames,
+  isEarlyAwardableTwitchReward,
   matchClaimedReward,
   normalizeImageUrl,
   normalizeText,
+  resolveDropClaimedStatus,
   toIsoDate,
   toNumber,
 };
@@ -422,6 +428,7 @@ export function parseCampaignDrops(
       0;
     const benefitNames = extractBenefitNames(drop);
     const benefitIds = extractBenefitIds(drop);
+    const rewardDistributionTypes = extractBenefitDistributionTypes(drop);
     const dropStartsAt = toIsoDate(drop.startAt) ?? campaignStartsAt;
     const dropEndsAt = toIsoDate(drop.endAt) ?? campaignEndsAt;
     const allowMissingGlobalAwardedAt = isBadgeOrEmoteDrop(drop) || isTwitchNativeCampaign(campaign);
@@ -436,9 +443,13 @@ export function parseCampaignDrops(
     );
     const claimedFromGameEvents = idMatch || nameMatch || globalIdMatch;
     const claimedFromInventory = inventoryState?.claimed ?? Boolean(self.isClaimed ?? drop.isClaimed);
-    // Inventory state is authoritative when present: don't let a same-named benefit
-    // claimed in a sibling campaign mark this drop as done.
-    const claimed = inventoryState ? claimedFromInventory : claimedFromInventory || claimedFromGameEvents;
+    const isEarlyAwardable = isEarlyAwardableTwitchReward(rewardDistributionTypes);
+    const claimed = resolveDropClaimedStatus(
+      claimedFromInventory,
+      claimedFromGameEvents,
+      inventoryState != null,
+      isEarlyAwardable,
+    );
     const claimableFromApi =
       !claimed && (inventoryState?.claimable ?? Boolean(self.isClaimable ?? self.canClaim));
     const earnedFromProgress = Boolean(
@@ -481,12 +492,15 @@ export function parseCampaignDrops(
       claimed,
       claimable,
       campaignId: campaignId || undefined,
+      startsAt: dropStartsAt,
       endsAt,
       expiresInMs: computeExpiry(endsAt).expiresInMs,
       status: normalizeDropStatus(progress, claimed, claimable),
       requiredMinutes,
       remainingMinutes,
       progressSource: 'campaign',
+      benefitIds,
+      rewardDistributionTypes,
       ...(!isFarmable && { dropType: 'event-based' as const }),
     } satisfies TwitchDrop;
   });
@@ -512,6 +526,7 @@ function parseEventBasedDrops(
     const parsedDropId = normalizeText(drop.id);
     const benefitNames = extractBenefitNames(drop);
     const benefitIds = extractBenefitIds(drop);
+    const rewardDistributionTypes = extractBenefitDistributionTypes(drop);
     const dropStartsAt = toIsoDate(drop.startAt) ?? campaignStartsAt;
     const dropEndsAt = toIsoDate(drop.endAt) ?? campaignEndsAt;
     const allowMissingGlobalAwardedAt = isBadgeOrEmoteDrop(drop) || isTwitchNativeCampaign(campaign);
@@ -543,12 +558,15 @@ function parseEventBasedDrops(
       claimed,
       claimable: false,
       campaignId: campaignId || undefined,
+      startsAt: dropStartsAt,
       endsAt,
       expiresInMs: computeExpiry(endsAt).expiresInMs,
       status: normalizeDropStatus(progress, claimed, false),
       requiredMinutes: null,
       remainingMinutes: null,
       progressSource: 'campaign',
+      benefitIds,
+      rewardDistributionTypes,
       dropType: 'event-based',
     } satisfies TwitchDrop;
   });
@@ -781,7 +799,10 @@ export class TwitchApiClient {
       logVerboseWarn('[DropHunter] Expected dropCampaignsInProgress field in inventory response');
     }
 
-    const drops = applyInventoryToDrops(baseDrops, inventoryRaw);
+    const drops = applyEarlyTwitchRewardClaimsToDrops(
+      applyInventoryToDrops(baseDrops, inventoryRaw),
+      inventoryRaw,
+    );
     return {
       games: [],
       drops,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,9 @@ export interface TwitchDrop {
   remainingMinutes?: number | null;
   progressSource?: DropProgressSource;
   dropType?: DropType;
+  benefitIds?: string[];
+  rewardDistributionTypes?: string[];
+  startsAt?: string | null;
 }
 
 export interface TwitchStreamer {

--- a/tests/api-operations.test.ts
+++ b/tests/api-operations.test.ts
@@ -458,6 +458,184 @@ describe('fetchDropsSnapshotFromApi', () => {
     expect(drop?.status).toBe('completed');
   });
 
+  test('marks badge drops claimed from gameEventDrops when inventory still shows partial progress', async () => {
+    const { fetchDropsSnapshotFromApi } = await import('../src/background/api-operations.ts');
+
+    const state = createMinimalState();
+    const session = createSession();
+    const startsAt = '2026-05-18T06:00:00.000Z';
+    const endsAt = '2026-05-29T21:29:00.000Z';
+    const benefit = {
+      id: 'benefit-road-to-twitchcon-badge',
+      name: 'RoadToTwitchCon26 Badge',
+      distributionType: 'BADGE',
+    };
+    const campaign = {
+      id: 'campaign-road-to-twitchcon-badge',
+      name: 'RoadtoTwitchCon26',
+      status: 'ACTIVE',
+      startAt: startsAt,
+      endAt: endsAt,
+      game: {
+        displayName: 'IRL',
+        name: 'IRL',
+        slug: 'irl',
+        boxArtURL: 'https://example.com/irl.png',
+      },
+      timeBasedDrops: [
+        {
+          id: 'road-to-twitchcon-badge-drop',
+          name: 'RoadToTwitchCon26',
+          startAt: startsAt,
+          endAt: endsAt,
+          requiredMinutesWatched: 60,
+          benefitEdges: [{ benefit }],
+          self: {
+            currentMinutesWatched: 58,
+            isClaimed: false,
+            isClaimable: false,
+          },
+        },
+      ],
+      eventBasedDrops: [],
+    };
+
+    originalFetch = installFetchMock([
+      async () => ({ data: { currentUser: { dropCampaigns: [campaign] } } }),
+      async () => ({
+        data: {
+          currentUser: {
+            inventory: {
+              dropCampaignsInProgress: [
+                {
+                  id: campaign.id,
+                  timeBasedDrops: [
+                    {
+                      id: 'road-to-twitchcon-badge-drop',
+                      requiredMinutesWatched: 60,
+                      self: {
+                        currentMinutesWatched: 58,
+                        isClaimed: false,
+                        isClaimable: false,
+                      },
+                    },
+                  ],
+                },
+              ],
+              gameEventDrops: [
+                {
+                  id: benefit.id,
+                  name: benefit.name,
+                  lastAwardedAt: '2026-05-19T08:00:00.000Z',
+                  game: { displayName: 'IRL' },
+                },
+              ],
+            },
+          },
+        },
+      }),
+      async () => [{ data: { user: { dropCampaign: campaign } } }],
+    ]);
+
+    const result = await fetchDropsSnapshotFromApi(state, session);
+    const drop = result?.drops[0];
+
+    expect(drop?.claimed).toBe(true);
+    expect(drop?.progress).toBe(100);
+    expect(drop?.remainingMinutes).toBe(0);
+    expect(drop?.status).toBe('completed');
+    expect(drop?.rewardDistributionTypes).toContain('BADGE');
+  });
+
+  test('marks emote drops claimed from gameEventDrops when inventory still shows partial progress', async () => {
+    const { fetchDropsSnapshotFromApi } = await import('../src/background/api-operations.ts');
+
+    const state = createMinimalState();
+    const session = createSession();
+    const startsAt = '2026-05-18T06:00:00.000Z';
+    const endsAt = '2026-05-29T21:29:00.000Z';
+    const benefit = {
+      id: 'benefit-twitch-emote',
+      name: 'Twitch Emote',
+      distributionType: 'EMOTE',
+    };
+    const campaign = {
+      id: 'campaign-twitch-emote',
+      name: 'Twitch Emote Campaign',
+      status: 'ACTIVE',
+      startAt: startsAt,
+      endAt: endsAt,
+      game: {
+        displayName: 'IRL',
+        name: 'IRL',
+        slug: 'irl',
+        boxArtURL: 'https://example.com/irl.png',
+      },
+      timeBasedDrops: [
+        {
+          id: 'twitch-emote-drop',
+          name: 'Twitch Emote',
+          startAt: startsAt,
+          endAt: endsAt,
+          requiredMinutesWatched: 60,
+          benefitEdges: [{ benefit }],
+          self: {
+            currentMinutesWatched: 58,
+            isClaimed: false,
+            isClaimable: false,
+          },
+        },
+      ],
+      eventBasedDrops: [],
+    };
+
+    originalFetch = installFetchMock([
+      async () => ({ data: { currentUser: { dropCampaigns: [campaign] } } }),
+      async () => ({
+        data: {
+          currentUser: {
+            inventory: {
+              dropCampaignsInProgress: [
+                {
+                  id: campaign.id,
+                  timeBasedDrops: [
+                    {
+                      id: 'twitch-emote-drop',
+                      requiredMinutesWatched: 60,
+                      self: {
+                        currentMinutesWatched: 58,
+                        isClaimed: false,
+                        isClaimable: false,
+                      },
+                    },
+                  ],
+                },
+              ],
+              gameEventDrops: [
+                {
+                  id: benefit.id,
+                  name: benefit.name,
+                  lastAwardedAt: '2026-05-19T08:00:00.000Z',
+                  game: { displayName: 'IRL' },
+                },
+              ],
+            },
+          },
+        },
+      }),
+      async () => [{ data: { user: { dropCampaign: campaign } } }],
+    ]);
+
+    const result = await fetchDropsSnapshotFromApi(state, session);
+    const drop = result?.drops[0];
+
+    expect(drop?.claimed).toBe(true);
+    expect(drop?.progress).toBe(100);
+    expect(drop?.remainingMinutes).toBe(0);
+    expect(drop?.status).toBe('completed');
+    expect(drop?.rewardDistributionTypes).toContain('EMOTE');
+  });
+
   test('does not mark a drop claimed when the awarded timestamp is outside the drop window', async () => {
     const { fetchDropsSnapshotFromApi } = await import('../src/background/api-operations.ts');
 
@@ -1339,6 +1517,76 @@ describe('fetchInventorySnapshotFromApi', () => {
     expect(result?.drops[0].remainingMinutes).toBe(60);
     expect(result?.drops[0].progressSource).toBe('inventory');
     expect(state.apiConsecutiveFailures).toBe(0);
+  });
+
+  test('marks early-awarded emote drops claimed during inventory-only refresh', async () => {
+    const { fetchInventorySnapshotFromApi } = await import('../src/background/api-operations.ts');
+
+    const state = createMinimalState();
+    const session = createSession();
+    const startsAt = '2026-05-18T06:00:00.000Z';
+    const endsAt = '2026-05-29T21:29:00.000Z';
+    const cachedDrops: TwitchDrop[] = [
+      {
+        id: 'twitch-emote-drop',
+        name: 'Twitch Emote',
+        gameId: 'campaign-twitch-emote',
+        gameName: 'IRL',
+        imageUrl: 'https://example.com/drop.png',
+        progress: 98,
+        currentMinutes: 58,
+        claimed: false,
+        campaignId: 'campaign-twitch-emote',
+        startsAt,
+        endsAt,
+        requiredMinutes: 60,
+        remainingMinutes: 2,
+        benefitIds: ['benefit-twitch-emote'],
+        rewardDistributionTypes: ['EMOTE'],
+      },
+    ];
+
+    originalFetch = installFetchMock([
+      async () => ({
+        data: {
+          currentUser: {
+            inventory: {
+              dropCampaignsInProgress: [
+                {
+                  id: 'campaign-twitch-emote',
+                  timeBasedDrops: [
+                    {
+                      id: 'twitch-emote-drop',
+                      requiredMinutesWatched: 60,
+                      self: {
+                        currentMinutesWatched: 58,
+                        isClaimed: false,
+                        isClaimable: false,
+                      },
+                    },
+                  ],
+                },
+              ],
+              gameEventDrops: [
+                {
+                  id: 'benefit-twitch-emote',
+                  name: 'Twitch Emote',
+                  lastAwardedAt: '2026-05-19T08:00:00.000Z',
+                  game: { displayName: 'IRL' },
+                },
+              ],
+            },
+          },
+        },
+      }),
+    ]);
+
+    const result = await fetchInventorySnapshotFromApi(state, session, cachedDrops);
+
+    expect(result).not.toBeNull();
+    expect(result?.drops[0].claimed).toBe(true);
+    expect(result?.drops[0].progress).toBe(100);
+    expect(result?.drops[0].status).toBe('completed');
   });
 
   test('rethrows inventory auth errors so wrappers can refresh the Twitch session', async () => {

--- a/tests/client-parsing.test.ts
+++ b/tests/client-parsing.test.ts
@@ -764,4 +764,66 @@ describe('parseCampaignDrops — inventory authoritative over game-event name ma
     expect(drops[0]?.status).not.toBe('completed');
     expect(drops[0]?.remainingMinutes).toBeGreaterThan(0);
   });
+
+  test('marks emote drops claimed from gameEventDrops when inventory still shows partial progress', () => {
+    const startsAt = '2026-05-18T06:00:00.000Z';
+    const endsAt = '2026-05-29T21:29:00.000Z';
+    const benefit = {
+      id: 'benefit-twitch-emote',
+      name: 'Twitch Emote',
+      distributionType: 'EMOTE',
+    };
+    const inventory = {
+      dropCampaignsInProgress: [
+        {
+          id: 'campaign-twitch-emote',
+          timeBasedDrops: [
+            {
+              id: 'twitch-emote-drop',
+              requiredMinutesWatched: 60,
+              self: {
+                currentMinutesWatched: 58,
+                isClaimed: false,
+                isClaimable: false,
+              },
+            },
+          ],
+        },
+      ],
+      gameEventDrops: [
+        {
+          id: benefit.id,
+          name: benefit.name,
+          lastAwardedAt: '2026-05-19T08:00:00.000Z',
+          game: { displayName: 'IRL' },
+        },
+      ],
+    };
+    const maps = buildInventoryDropMaps(inventory);
+    const campaign = {
+      id: 'campaign-twitch-emote',
+      startAt: startsAt,
+      endAt: endsAt,
+      timeBasedDrops: [
+        {
+          id: 'twitch-emote-drop',
+          name: 'Twitch Emote',
+          startAt: startsAt,
+          endAt: endsAt,
+          requiredMinutesWatched: 60,
+          benefitEdges: [{ benefit }],
+          self: { currentMinutesWatched: 58, isClaimed: false, isClaimable: false },
+        },
+      ],
+    };
+    const game = { id: 'g-irl', name: 'IRL', imageUrl: '', campaignId: 'campaign-twitch-emote' };
+    const claimedRewards = buildClaimedRewardLookup(inventory);
+    const globalClaimedRewards = buildGlobalClaimedRewardEntry(inventory);
+
+    const drops = parseCampaignDrops(campaign, game as never, maps, claimedRewards, globalClaimedRewards);
+    expect(drops[0]?.claimed).toBe(true);
+    expect(drops[0]?.progress).toBe(100);
+    expect(drops[0]?.status).toBe('completed');
+    expect(drops[0]?.rewardDistributionTypes).toContain('EMOTE');
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When Twitch awards an emote or badge before watch time completes, the extension could stay stuck at ~98% even though the reward was already present in `gameEventDrops`.

During active farming, `dropCampaignsInProgress` was treated as authoritative and ignored the `gameEventDrops` match.

## Solution

- For drops with `distributionType` **BADGE** or **EMOTE**, allow early completion when the benefit appears in `gameEventDrops`, even if in-progress inventory still shows partial watch time.
- Persist `benefitIds`, `rewardDistributionTypes`, and `startsAt` on `TwitchDrop` for inventory-only refreshes.
- Apply the same `gameEventDrops` match in `fetchInventorySnapshot` so completion is detected on the next tick without waiting for the full ~2 minute refresh.

## Tests

- Badge/emote with populated `dropCampaignsInProgress` (58/60 min) + benefit in `gameEventDrops` → `claimed: true`
- Inventory-only refresh for early-awarded emote
- Overwatch camp-2 isolation unchanged (benefits without BADGE/EMOTE are not marked claimed)

## Verification

```bash
bun test tests/api-operations.test.ts tests/client-parsing.test.ts tests/merge-drops.test.ts
bun run test:ts
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1540-7d5d-7153-bc2c-55e5a664a0d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1540-7d5d-7153-bc2c-55e5a664a0d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

