### PR TITLE
Add drag-and-drop queue reordering in popup

### DIFF
--- a/src/background/farming-session.ts
+++ b/src/background/farming-session.ts
@@ -21,6 +21,7 @@ import {
   enterPersistentRecovery as enterPersistentRecoveryExt,
   handleAddToQueue as handleAddToQueueExt,
   handleRemoveFromQueue as handleRemoveFromQueueExt,
+  handleReorderQueue as handleReorderQueueExt,
   handleSetSelectedGame as handleSetSelectedGameExt,
   handleStartFarming as handleStartFarmingExt,
   normalizeQueueSelection as normalizeQueueSelectionExt,
@@ -400,6 +401,13 @@ export function createFarmingSession(state: ServiceWorkerState, adapters: Farmin
     );
   }
 
+  async function handleReorderQueue(payload: { fromIndex?: number; toIndex?: number }) {
+    return handleReorderQueueExt(state, payload, {
+      onTrackActivity: adapters.trackActivity,
+      onSaveState: adapters.saveState,
+    });
+  }
+
   async function handleClearQueue() {
     await adapters.trackActivity('clear-queue');
     state.appState.queue = [];
@@ -451,6 +459,7 @@ export function createFarmingSession(state: ServiceWorkerState, adapters: Farmin
     handlePauseFarming,
     handleRefreshDrops,
     handleRemoveFromQueue,
+    handleReorderQueue,
     handleResumeFarming,
     handleSetSelectedGame,
     handleStartFarming,

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -26,6 +26,7 @@ export interface RuntimeMessageHandlers {
   markDropsRefreshNoticeSeen: RuntimeMessageHandler<'MARK_DROPS_REFRESH_NOTICE_SEEN'>;
   addToQueue: RuntimeMessageHandler<'ADD_TO_QUEUE'>;
   removeFromQueue: RuntimeMessageHandler<'REMOVE_FROM_QUEUE'>;
+  reorderQueue: RuntimeMessageHandler<'REORDER_QUEUE'>;
   clearQueue: RuntimeMessageHandler<'CLEAR_QUEUE'>;
   startFarming: RuntimeMessageHandler<'START_FARMING'>;
   setSelectedGame: RuntimeMessageHandler<'SET_SELECTED_GAME'>;
@@ -98,6 +99,8 @@ export function createRuntimeMessageListener(handlers: RuntimeMessageHandlers): 
         return respondAsync(() => handlers.addToQueue(message, sender), sendResponse);
       case 'REMOVE_FROM_QUEUE':
         return respondAsync(() => handlers.removeFromQueue(message, sender), sendResponse);
+      case 'REORDER_QUEUE':
+        return respondAsync(() => handlers.reorderQueue(message, sender), sendResponse);
       case 'CLEAR_QUEUE':
         return respondAsync(() => handlers.clearQueue(message, sender), sendResponse);
       case 'START_FARMING':

--- a/src/background/queue-management.ts
+++ b/src/background/queue-management.ts
@@ -1884,7 +1884,12 @@ export async function handleReorderQueue(
 
   const fromIndex = payload?.fromIndex;
   const toIndex = payload?.toIndex;
-  if (!Number.isInteger(fromIndex) || !Number.isInteger(toIndex)) {
+  if (
+    typeof fromIndex !== 'number' ||
+    typeof toIndex !== 'number' ||
+    !Number.isInteger(fromIndex) ||
+    !Number.isInteger(toIndex)
+  ) {
     return { success: false, error: 'Invalid queue indices.' };
   }
 

--- a/src/background/queue-management.ts
+++ b/src/background/queue-management.ts
@@ -249,6 +249,22 @@ export function pushGameToQueue(state: ServiceWorkerState, game: TwitchGame) {
   state.appState.queue = [...state.appState.queue, game];
 }
 
+export function reorderQueue(state: ServiceWorkerState, fromIndex: number, toIndex: number): boolean {
+  const queue = state.appState.queue;
+  if (fromIndex < 0 || toIndex < 0 || fromIndex >= queue.length || toIndex >= queue.length) {
+    return false;
+  }
+  if (fromIndex === toIndex) {
+    return false;
+  }
+
+  const next = [...queue];
+  const [item] = next.splice(fromIndex, 1);
+  next.splice(toIndex, 0, item);
+  state.appState.queue = next;
+  return true;
+}
+
 export function resetStreamTrackingState(state: ServiceWorkerState) {
   state.invalidStreamChecks = 0;
   state.lastStreamRotationAt = 0;
@@ -1850,4 +1866,33 @@ export async function handleRemoveFromQueue(
 
   await callbacks.onSaveState(state);
   return { success: true, removed, queueLength: state.appState.queue.length };
+}
+
+export async function handleReorderQueue(
+  state: ServiceWorkerState,
+  payload: { fromIndex?: number; toIndex?: number },
+  callbacks: {
+    onTrackActivity: (reason: string) => Promise<void>;
+    onSaveState: (state: ServiceWorkerState) => Promise<void>;
+  },
+): Promise<{ success: boolean; reordered?: boolean; error?: string; queueLength?: number }> {
+  await callbacks.onTrackActivity('reorder-queue');
+
+  if (state.appState.isRunning) {
+    return { success: false, error: 'Cannot reorder queue while farming is active.' };
+  }
+
+  const fromIndex = payload?.fromIndex;
+  const toIndex = payload?.toIndex;
+  if (!Number.isInteger(fromIndex) || !Number.isInteger(toIndex)) {
+    return { success: false, error: 'Invalid queue indices.' };
+  }
+
+  const reordered = reorderQueue(state, fromIndex, toIndex);
+  if (!reordered) {
+    return { success: false, error: 'Invalid queue indices.' };
+  }
+
+  await callbacks.onSaveState(state);
+  return { success: true, reordered: true, queueLength: state.appState.queue.length };
 }

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -985,6 +985,7 @@ export function startServiceWorker(): void {
     markDropsRefreshNoticeSeen: (message) => handleMarkDropsRefreshNoticeSeen(message.payload),
     addToQueue: (message) => farmingSession.handleAddToQueue(message.payload),
     removeFromQueue: (message) => farmingSession.handleRemoveFromQueue(message.payload),
+    reorderQueue: (message) => farmingSession.handleReorderQueue(message.payload),
     clearQueue: () => farmingSession.handleClearQueue(),
     startFarming: (message) => farmingSession.handleStartFarming(message.payload),
     setSelectedGame: (message) => farmingSession.handleSetSelectedGame(message.payload),

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -175,6 +175,21 @@ function App() {
     }
   };
 
+  const handleReorderQueue = async (fromIndex: number, toIndex: number) => {
+    try {
+      const response = await sendRuntimeMessage({
+        type: 'REORDER_QUEUE',
+        payload: { fromIndex, toIndex },
+      });
+      if (!response?.success) {
+        setQueueMessage(response?.error ?? 'Unable to reorder queue.');
+      }
+    } catch (err: unknown) {
+      logPopupWarn('REORDER_QUEUE failed:', err);
+      setQueueMessage('Unable to reorder queue.');
+    }
+  };
+
   const withAction = useCallback(
     async (action: () => Promise<void>) => {
       if (actionLoading) return;
@@ -304,6 +319,7 @@ function App() {
           onAddToQueue={() => void handleAddToQueue()}
           onRemoveFromQueue={(game) => void handleRemoveFromQueue(game)}
           onClearQueue={() => void handleClearQueue()}
+          onReorderQueue={(fromIndex, toIndex) => void handleReorderQueue(fromIndex, toIndex)}
           onStart={handleStart}
         />
       )}

--- a/src/popup/components/MainView.tsx
+++ b/src/popup/components/MainView.tsx
@@ -41,6 +41,7 @@ export interface MainViewProps {
   onAddToQueue: () => void;
   onRemoveFromQueue: (game: TwitchGame) => void;
   onClearQueue: () => void;
+  onReorderQueue: (fromIndex: number, toIndex: number) => void;
   onStart: () => void;
 }
 
@@ -75,6 +76,7 @@ export function MainView({
   onAddToQueue,
   onRemoveFromQueue,
   onClearQueue,
+  onReorderQueue,
   onStart,
 }: MainViewProps) {
   return (
@@ -160,6 +162,7 @@ export function MainView({
           isRunning={state.isRunning}
           onRemove={onRemoveFromQueue}
           onClear={onClearQueue}
+          onReorder={onReorderQueue}
         />
 
         {/* Start button (only when not running) */}

--- a/src/popup/components/QueueChips.tsx
+++ b/src/popup/components/QueueChips.tsx
@@ -1,6 +1,7 @@
 // Extracted from src/popup/App.tsx (QueueChips component).
 import { getGameDisplayLabel } from '../../shared/game-selection';
 import type { TwitchGame } from '../../types';
+import { useQueueDragReorder } from '../hooks/useQueueDragReorder';
 import { isSameQueuedGame, queueGameIdentity } from '../queue-start';
 
 export interface QueueChipsProps {
@@ -9,9 +10,21 @@ export interface QueueChipsProps {
   isRunning: boolean;
   onRemove: (game: TwitchGame) => void;
   onClear: () => void;
+  onReorder: (fromIndex: number, toIndex: number) => void;
 }
 
-export function QueueChips({ selectedGame, queueGames, isRunning, onRemove, onClear }: QueueChipsProps) {
+export function QueueChips({
+  selectedGame,
+  queueGames,
+  isRunning,
+  onRemove,
+  onClear,
+  onReorder,
+}: QueueChipsProps) {
+  const canReorder = !isRunning && queueGames.length >= 2;
+  const { dragIndex, dropIndex, handleDragStart, handleDragEnd, handleDragOver, handleDrop } =
+    useQueueDragReorder(onReorder);
+
   const selectedNotInQueue =
     !isRunning &&
     !!selectedGame &&
@@ -32,25 +45,50 @@ export function QueueChips({ selectedGame, queueGames, isRunning, onRemove, onCl
           <span className="ml-1 text-green-400/80">↑ first</span>
         </span>
       )}
-      {queueGames.map((game) => (
-        <span
-          key={queueGameIdentity(game)}
-          className="inline-flex max-w-full items-center gap-0.5 rounded-full bg-[color:var(--dh-surface-3)] px-2 py-0.5 text-[11px] text-[color:var(--dh-text-soft)]"
-        >
-          {game.allDropsCompleted ? '✅ ' : ''}
-          <span className="truncate">{getGameDisplayLabel(game)}</span>
-          {!isRunning && (
-            <button
-              type="button"
-              onClick={() => onRemove(game)}
-              className="dh-focus ml-0.5 rounded text-[color:var(--dh-muted)] hover:text-[color:var(--dh-text)]"
-              aria-label={`Remove ${getGameDisplayLabel(game)} from queue`}
+      <div role="list" className="contents">
+        {queueGames.map((game, index) => {
+          const label = getGameDisplayLabel(game);
+          const isDragging = dragIndex === index;
+          const isDropTarget = dropIndex === index && dragIndex !== null && dragIndex !== index;
+
+          return (
+            <span
+              key={queueGameIdentity(game)}
+              role="listitem"
+              onDragOver={canReorder ? handleDragOver(index) : undefined}
+              onDrop={canReorder ? handleDrop(index) : undefined}
+              className={`inline-flex max-w-full items-center gap-0.5 rounded-full bg-[color:var(--dh-surface-3)] px-2 py-0.5 text-[11px] text-[color:var(--dh-text-soft)] ${
+                isDragging ? 'opacity-60' : ''
+              } ${isDropTarget ? 'ring-1 ring-[color:var(--dh-accent)]' : ''}`}
             >
-              ×
-            </button>
-          )}
-        </span>
-      ))}
+              {canReorder && (
+                <button
+                  type="button"
+                  draggable
+                  onDragStart={handleDragStart(index)}
+                  onDragEnd={handleDragEnd}
+                  className="dh-focus -ml-0.5 cursor-grab rounded px-0.5 text-[10px] text-[color:var(--dh-muted)] active:cursor-grabbing hover:text-[color:var(--dh-text)]"
+                  aria-label={`Reorder ${label}`}
+                >
+                  ⠿
+                </button>
+              )}
+              {game.allDropsCompleted ? '✅ ' : ''}
+              <span className="truncate">{label}</span>
+              {!isRunning && (
+                <button
+                  type="button"
+                  onClick={() => onRemove(game)}
+                  className="dh-focus ml-0.5 rounded text-[color:var(--dh-muted)] hover:text-[color:var(--dh-text)]"
+                  aria-label={`Remove ${label} from queue`}
+                >
+                  ×
+                </button>
+              )}
+            </span>
+          );
+        })}
+      </div>
       {!isRunning && (
         <button
           type="button"

--- a/src/popup/components/QueueChips.tsx
+++ b/src/popup/components/QueueChips.tsx
@@ -45,16 +45,15 @@ export function QueueChips({
           <span className="ml-1 text-green-400/80">↑ first</span>
         </span>
       )}
-      <div role="list" className="contents">
+      <ul className="contents">
         {queueGames.map((game, index) => {
           const label = getGameDisplayLabel(game);
           const isDragging = dragIndex === index;
           const isDropTarget = dropIndex === index && dragIndex !== null && dragIndex !== index;
 
           return (
-            <span
+            <li
               key={queueGameIdentity(game)}
-              role="listitem"
               onDragOver={canReorder ? handleDragOver(index) : undefined}
               onDrop={canReorder ? handleDrop(index) : undefined}
               className={`inline-flex max-w-full items-center gap-0.5 rounded-full bg-[color:var(--dh-surface-3)] px-2 py-0.5 text-[11px] text-[color:var(--dh-text-soft)] ${
@@ -85,10 +84,10 @@ export function QueueChips({
                   ×
                 </button>
               )}
-            </span>
+            </li>
           );
         })}
-      </div>
+      </ul>
       {!isRunning && (
         <button
           type="button"

--- a/src/popup/hooks/useQueueDragReorder.ts
+++ b/src/popup/hooks/useQueueDragReorder.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState, type DragEvent } from 'react';
+import { type DragEvent, useCallback, useState } from 'react';
 
 export function useQueueDragReorder(onReorder: (fromIndex: number, toIndex: number) => void) {
   const [dragIndex, setDragIndex] = useState<number | null>(null);
@@ -18,7 +18,7 @@ export function useQueueDragReorder(onReorder: (fromIndex: number, toIndex: numb
   }, []);
 
   const handleDragOver = useCallback((index: number) => {
-    return (event: React.DragEvent<HTMLSpanElement>) => {
+    return (event: DragEvent<HTMLSpanElement>) => {
       event.preventDefault();
       event.dataTransfer.dropEffect = 'move';
       setDropIndex(index);
@@ -27,7 +27,7 @@ export function useQueueDragReorder(onReorder: (fromIndex: number, toIndex: numb
 
   const handleDrop = useCallback(
     (toIndex: number) => {
-      return (event: React.DragEvent<HTMLSpanElement>) => {
+      return (event: DragEvent<HTMLSpanElement>) => {
         event.preventDefault();
         const fromIndex = Number(event.dataTransfer.getData('text/plain'));
         setDragIndex(null);

--- a/src/popup/hooks/useQueueDragReorder.ts
+++ b/src/popup/hooks/useQueueDragReorder.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState, type DragEvent } from 'react';
+
+export function useQueueDragReorder(onReorder: (fromIndex: number, toIndex: number) => void) {
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [dropIndex, setDropIndex] = useState<number | null>(null);
+
+  const handleDragStart = useCallback((index: number) => {
+    return (event: DragEvent<HTMLButtonElement>) => {
+      event.dataTransfer.setData('text/plain', String(index));
+      event.dataTransfer.effectAllowed = 'move';
+      setDragIndex(index);
+    };
+  }, []);
+
+  const handleDragEnd = useCallback(() => {
+    setDragIndex(null);
+    setDropIndex(null);
+  }, []);
+
+  const handleDragOver = useCallback((index: number) => {
+    return (event: React.DragEvent<HTMLSpanElement>) => {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'move';
+      setDropIndex(index);
+    };
+  }, []);
+
+  const handleDrop = useCallback(
+    (toIndex: number) => {
+      return (event: React.DragEvent<HTMLSpanElement>) => {
+        event.preventDefault();
+        const fromIndex = Number(event.dataTransfer.getData('text/plain'));
+        setDragIndex(null);
+        setDropIndex(null);
+        if (!Number.isInteger(fromIndex) || fromIndex === toIndex) {
+          return;
+        }
+        onReorder(fromIndex, toIndex);
+      };
+    },
+    [onReorder],
+  );
+
+  return {
+    dragIndex,
+    dropIndex,
+    handleDragStart,
+    handleDragEnd,
+    handleDragOver,
+    handleDrop,
+  };
+}

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -26,6 +26,7 @@ export const RUNTIME_MESSAGE_TYPES = [
   'SET_PREFERRED_STREAMER_LANGUAGE',
   'ADD_TO_QUEUE',
   'REMOVE_FROM_QUEUE',
+  'REORDER_QUEUE',
   'CLEAR_QUEUE',
   'START_FARMING',
   'SET_SELECTED_GAME',
@@ -65,6 +66,7 @@ export type RuntimeRequest =
   | { type: 'SET_PREFERRED_STREAMER_LANGUAGE'; payload?: { language?: string | null } }
   | { type: 'ADD_TO_QUEUE'; payload: { game?: TwitchGame } }
   | { type: 'REMOVE_FROM_QUEUE'; payload: { game?: TwitchGame; gameId?: string; campaignId?: string } }
+  | { type: 'REORDER_QUEUE'; payload: { fromIndex: number; toIndex: number } }
   | { type: 'CLEAR_QUEUE' }
   | { type: 'START_FARMING'; payload: { game?: TwitchGame } }
   | { type: 'SET_SELECTED_GAME'; payload: { game: TwitchGame } }
@@ -113,6 +115,7 @@ export type RuntimeResponseByType = {
   };
   ADD_TO_QUEUE: { success: boolean; added?: boolean; reason?: string; error?: string };
   REMOVE_FROM_QUEUE: { success: boolean; removed?: boolean; error?: string };
+  REORDER_QUEUE: { success: boolean; reordered?: boolean; error?: string };
   CLEAR_QUEUE: { success: boolean; error?: string };
   START_FARMING: { success: boolean; error?: string };
   SET_SELECTED_GAME: { success: boolean; selectedGame?: TwitchGame | null; error?: string };
@@ -215,6 +218,15 @@ function isRuntimePayloadValid(type: RuntimeMessageType, payload: unknown): bool
         (payload.game === undefined || isTwitchGameLike(payload.game)) &&
         (payload.gameId === undefined || typeof payload.gameId === 'string') &&
         (payload.campaignId === undefined || typeof payload.campaignId === 'string')
+      );
+    case 'REORDER_QUEUE':
+      return (
+        isRecord(payload) &&
+        Number.isInteger(payload.fromIndex) &&
+        Number.isInteger(payload.toIndex) &&
+        (payload.fromIndex as number) >= 0 &&
+        (payload.toIndex as number) >= 0 &&
+        payload.fromIndex !== payload.toIndex
       );
     case 'OPEN_DROPS_PAGE_AND_REFRESH':
       return (

--- a/tests/message-router.test.ts
+++ b/tests/message-router.test.ts
@@ -15,6 +15,7 @@ function createHandlers(overrides: Partial<RuntimeMessageHandlers> = {}): Runtim
     markDropsRefreshNoticeSeen: missing,
     addToQueue: missing,
     removeFromQueue: missing,
+    reorderQueue: missing,
     clearQueue: missing,
     startFarming: missing,
     setSelectedGame: missing,
@@ -100,6 +101,47 @@ describe('runtime message router', () => {
 
     expect(result.keepChannelOpen).toBe(true);
     expect(result.response).toEqual({ success: false, error: 'Unsupported message target' });
+  });
+
+  test('dispatches REORDER_QUEUE to the reorder handler', async () => {
+    let reorderCalled = false;
+    const listener = createRuntimeMessageListener(
+      createHandlers({
+        reorderQueue: async (message) => {
+          reorderCalled = true;
+          expect(message.payload).toEqual({ fromIndex: 1, toIndex: 0 });
+          return { success: true, reordered: true };
+        },
+      }),
+    );
+
+    const result = await callListener(listener, {
+      type: 'REORDER_QUEUE',
+      payload: { fromIndex: 1, toIndex: 0 },
+    });
+
+    expect(reorderCalled).toBe(true);
+    expect(result.response).toEqual({ success: true, reordered: true });
+  });
+
+  test('rejects malformed REORDER_QUEUE payloads before invoking handlers', async () => {
+    let reorderCalled = false;
+    const listener = createRuntimeMessageListener(
+      createHandlers({
+        reorderQueue: async () => {
+          reorderCalled = true;
+          return { success: true };
+        },
+      }),
+    );
+
+    const result = await callListener(listener, {
+      type: 'REORDER_QUEUE',
+      payload: { fromIndex: 0, toIndex: 0 },
+    });
+
+    expect(result.response).toEqual({ success: false, error: 'Invalid message payload' });
+    expect(reorderCalled).toBe(false);
   });
 
   test('dispatches GET_CLAIM_LOG and CLEAR_CLAIM_LOG to the correct handlers', async () => {

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -67,4 +67,31 @@ describe('runtime message protocol', () => {
     expect(isRuntimeRequest({ type: 'CLEAR_CLAIM_LOG' })).toBe(true);
     expect(isRuntimeRequest({ type: 'GET_CLAIM_LOG', payload: { unexpected: true } })).toBe(true);
   });
+
+  test('validates REORDER_QUEUE payload', () => {
+    expect(
+      isRuntimeRequest({
+        type: 'REORDER_QUEUE',
+        payload: { fromIndex: 0, toIndex: 2 },
+      }),
+    ).toBe(true);
+    expect(
+      isRuntimeRequest({
+        type: 'REORDER_QUEUE',
+        payload: { fromIndex: -1, toIndex: 0 },
+      }),
+    ).toBe(false);
+    expect(
+      isRuntimeRequest({
+        type: 'REORDER_QUEUE',
+        payload: { fromIndex: 0, toIndex: 0 },
+      }),
+    ).toBe(false);
+    expect(
+      isRuntimeRequest({
+        type: 'REORDER_QUEUE',
+        payload: { fromIndex: 1.5, toIndex: 0 },
+      }),
+    ).toBe(false);
+  });
 });

--- a/tests/popup-source.test.ts
+++ b/tests/popup-source.test.ts
@@ -90,6 +90,16 @@ test('popup splits the main campaign UI into focused components', () => {
   expect(source).toContain('function RewardList');
 });
 
+test('popup queue chips support drag-and-drop reordering', () => {
+  const source = readPopupSource();
+
+  expect(source).toContain("type: 'REORDER_QUEUE'");
+  expect(source).toContain('role="list"');
+  expect(source).toContain('draggable');
+  expect(source).toContain('useQueueDragReorder');
+  expect(source).toContain('onReorder={onReorderQueue}');
+});
+
 test('popup async copy uses ellipsis glyphs instead of three-dot loading text', () => {
   const source = readPopupSource();
 

--- a/tests/popup-source.test.ts
+++ b/tests/popup-source.test.ts
@@ -94,7 +94,7 @@ test('popup queue chips support drag-and-drop reordering', () => {
   const source = readPopupSource();
 
   expect(source).toContain("type: 'REORDER_QUEUE'");
-  expect(source).toContain('role="list"');
+  expect(source).toContain('<ul className="contents">');
   expect(source).toContain('draggable');
   expect(source).toContain('useQueueDragReorder');
   expect(source).toContain('onReorder={onReorderQueue}');

--- a/tests/queue-management.test.ts
+++ b/tests/queue-management.test.ts
@@ -6,6 +6,7 @@ import {
   removeGameFromQueue,
   resolveGameFromState,
   pushGameToQueue,
+  reorderQueue,
   resetStreamTrackingState,
   applyStopState,
   acquireStreamerForSelectedGame,
@@ -15,6 +16,7 @@ import {
   skipCurrentGameAndAdvanceQueue,
   skipCurrentGameDueToStall,
   handleStartFarming,
+  handleReorderQueue,
   refreshDropsData,
   rotateStreamer,
   rotateStreamerIfInvalid,
@@ -260,6 +262,70 @@ describe('pushGameToQueue', () => {
     pushGameToQueue(state, game);
     expect(state.appState.queue).toHaveLength(1);
     expect(state.appState.queue[0].id).toBe('game-1');
+  });
+});
+
+describe('reorderQueue', () => {
+  test('moves a queue item forward', () => {
+    const state = createMinimalState();
+    const game1 = createGame({ id: 'game-1', campaignId: 'campaign-1' });
+    const game2 = createGame({ id: 'game-2', campaignId: 'campaign-2' });
+    const game3 = createGame({ id: 'game-3', campaignId: 'campaign-3' });
+    state.appState.queue = [game1, game2, game3];
+
+    expect(reorderQueue(state, 2, 0)).toBe(true);
+    expect(state.appState.queue.map((game) => game.campaignId)).toEqual([
+      'campaign-3',
+      'campaign-1',
+      'campaign-2',
+    ]);
+  });
+
+  test('moves a queue item backward', () => {
+    const state = createMinimalState();
+    const game1 = createGame({ id: 'game-1', campaignId: 'campaign-1' });
+    const game2 = createGame({ id: 'game-2', campaignId: 'campaign-2' });
+    state.appState.queue = [game1, game2];
+
+    expect(reorderQueue(state, 0, 1)).toBe(true);
+    expect(state.appState.queue.map((game) => game.campaignId)).toEqual(['campaign-2', 'campaign-1']);
+  });
+
+  test('rejects invalid indices and no-op reorders', () => {
+    const state = createMinimalState();
+    const game1 = createGame({ id: 'game-1' });
+    const game2 = createGame({ id: 'game-2' });
+    state.appState.queue = [game1, game2];
+
+    expect(reorderQueue(state, -1, 0)).toBe(false);
+    expect(reorderQueue(state, 0, 2)).toBe(false);
+    expect(reorderQueue(state, 0, 0)).toBe(false);
+    expect(state.appState.queue.map((game) => game.id)).toEqual(['game-1', 'game-2']);
+  });
+});
+
+describe('handleReorderQueue', () => {
+  test('rejects reorder while farming is active', async () => {
+    const state = createMinimalState();
+    const game1 = createGame({ id: 'game-1' });
+    const game2 = createGame({ id: 'game-2' });
+    state.appState.queue = [game1, game2];
+    state.appState.isRunning = true;
+
+    const result = await handleReorderQueue(
+      state,
+      { fromIndex: 0, toIndex: 1 },
+      {
+        onTrackActivity: async () => undefined,
+        onSaveState: async () => undefined,
+      },
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Cannot reorder queue while farming is active.',
+    });
+    expect(state.appState.queue.map((game) => game.id)).toEqual(['game-1', 'game-2']);
   });
 });
 

--- a/tests/service-worker.test.ts
+++ b/tests/service-worker.test.ts
@@ -1636,6 +1636,30 @@ describe('service worker message handlers', () => {
     expect(state.queue).toHaveLength(0);
   });
 
+  test('REORDER_QUEUE reorders persisted queue entries when farming is stopped', async () => {
+    await dispatchMessage({
+      type: 'UPDATE_GAMES',
+      payload: [demoGame, nextGame, thirdGame],
+    });
+    await addGameToQueue(demoGame);
+    await addGameToQueue(nextGame);
+    await addGameToQueue(thirdGame);
+
+    const response = await dispatchMessage({
+      type: 'REORDER_QUEUE',
+      payload: { fromIndex: 2, toIndex: 0 },
+    });
+
+    expect(response).toEqual({ success: true, reordered: true, queueLength: 3 });
+
+    const state = getAppStateFromStorage();
+    expect(state.queue.map((game) => game.campaignId)).toEqual([
+      'queue-third-campaign',
+      'campaign-1',
+      'queue-next-campaign',
+    ]);
+  });
+
   test('extension update preserves queue, selectedGame, settings, and isRunning', async () => {
     const chromeAny = (globalThis as unknown as { chrome: Record<string, unknown> }).chrome;
     const onInstalled = (chromeAny.runtime as Record<string, unknown>).onInstalled as ReturnType<


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `REORDER_QUEUE` runtime message with background splice logic to persist queue order changes.
- Enables native HTML5 drag-and-drop on queue chips via a small grip handle, without new dependencies.
- Keeps the existing chip layout and disables reordering while farming is active.

## UI changes

- Queue chips show a `⠿` drag handle when there are 2+ items and farming is stopped.
- Drag feedback: reduced opacity on the dragged chip, accent ring on the drop target.
- The green `↑ first` preview chip remains non-draggable.

## Test plan

- [x] `bun test tests/queue-management.test.ts tests/messages.test.ts tests/message-router.test.ts tests/service-worker.test.ts tests/popup-source.test.ts`
- [x] `bun run test:ts`
- [x] `bun run lint`
- [ ] Manual: add 3 campaigns to queue, drag to reorder, confirm order persists after popup reopen
- [ ] Manual: confirm reorder is disabled while farming is running

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f19c7-a8b6-7a1e-9839-09f76e571174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f19c7-a8b6-7a1e-9839-09f76e571174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

